### PR TITLE
[Common][Feat] 전체 API 엔드포인트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 
     //web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/com/bobeat/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bobeat/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.bobeat.backend.domain.auth.controller;
+
+import com.bobeat.backend.domain.auth.dto.request.SocialLoginRequest;
+import com.bobeat.backend.domain.auth.dto.response.SocialLoginResponse;
+import com.bobeat.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    @Operation(summary = "소셜 로그인", description = "카카오, 구글 토큰으로 로그인 또는 회원가입을 처리합니다.")
+    @PostMapping("/social-login")
+    public ApiResponse<SocialLoginResponse> socialLogin(@RequestBody SocialLoginRequest request) {
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/auth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/auth/dto/request/SocialLoginRequest.java
@@ -1,0 +1,13 @@
+package com.bobeat.backend.domain.auth.dto.request;
+
+import com.bobeat.backend.domain.member.entity.SocialProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "소셜 로그인 요청 DTO")
+public record SocialLoginRequest(
+        @Schema(description = "소셜 프로바이더", example = "KAKAO")
+        SocialProvider provider,
+        @Schema(description = "OAuth 토큰")
+        String oAuthToken
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,0 +1,22 @@
+package com.bobeat.backend.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "소셜 로그인 응답 DTO")
+public record SocialLoginResponse(
+        @Schema(description = "사용자 ID")
+        String userId,
+        @Schema(description = "닉네임")
+        String nickname,
+        @Schema(description = "혼밥 레벨")
+        int level,
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+        @Schema(description = "리프레시 토큰")
+        String refreshToken,
+        @Schema(description = "액세스 토큰 만료 시간 (초)")
+        long accessTokenExpiresIn,
+        @Schema(description = "리프레시 토큰 만료 시간 (초)")
+        long refreshTokenExpiresIn
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bobeat/backend/domain/member/controller/MemberController.java
@@ -1,0 +1,47 @@
+package com.bobeat.backend.domain.member.controller;
+
+import com.bobeat.backend.domain.member.dto.request.UpdateNicknameRequest;
+import com.bobeat.backend.domain.member.dto.response.MemberProfileResponse;
+import com.bobeat.backend.domain.member.dto.response.SavedStoreListResponse;
+import com.bobeat.backend.domain.member.dto.response.UpdateNicknameResponse;
+import com.bobeat.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Member", description = "회원 관련 API")
+@RestController
+@RequestMapping("/api/v1/users")
+public class MemberController {
+
+    @Operation(summary = "프로필 조회", description = "로그인한 사용자의 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ApiResponse<MemberProfileResponse> getMyProfile(
+            @Parameter(hidden = true) /*@AuthenticationPrincipal*/ Long memberId
+    ) {
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "닉네임 수정", description = "사용자 닉네임을 수정합니다.")
+    @PatchMapping("/me")
+    public ApiResponse<UpdateNicknameResponse> updateNickname(
+            @Parameter(hidden = true) /*@AuthenticationPrincipal*/ Long memberId,
+            @RequestBody UpdateNicknameRequest request
+    ) {
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "저장 목록 조회", description = "사용자가 저장한 식당 목록을 조회합니다.")
+    @GetMapping("/me/saved-restaurants")
+    public ApiResponse<SavedStoreListResponse> getSavedRestaurants(
+            @Parameter(hidden = true) /*@AuthenticationPrincipal*/ Long memberId
+    ) {
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/member/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/member/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,10 @@
+package com.bobeat.backend.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "닉네임 수정 요청 DTO")
+public record UpdateNicknameRequest(
+        @Schema(description = "새로운 닉네임")
+        String nickname
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,18 @@
+package com.bobeat.backend.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 프로필 조회 응답 DTO")
+public record MemberProfileResponse(
+        @Schema(description = "사용자 ID")
+        String userId,
+        @Schema(description = "닉네임")
+        String nickname,
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+        @Schema(description = "혼밥 레벨")
+        int level,
+        @Schema(description = "저장한 가게 수")
+        int scrapCount
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/member/dto/response/SavedStoreDto.java
+++ b/src/main/java/com/bobeat/backend/domain/member/dto/response/SavedStoreDto.java
@@ -1,0 +1,16 @@
+package com.bobeat.backend.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "저장한 가게 정보 DTO")
+public record SavedStoreDto(
+        @Schema(description = "가게 ID")
+        Long restaurantId,
+        @Schema(description = "가게 이름")
+        String name,
+        @Schema(description = "가게 대표 이미지 URL")
+        String thumbUrl,
+        @Schema(description = "혼밥 레벨")
+        int level
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/member/dto/response/SavedStoreListResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/member/dto/response/SavedStoreListResponse.java
@@ -1,0 +1,11 @@
+package com.bobeat.backend.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "저장한 가게 목록 조회 응답 DTO")
+public record SavedStoreListResponse(
+        @Schema(description = "저장한 가게 목록")
+        List<SavedStoreDto> restaurants
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/member/dto/response/UpdateNicknameResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/member/dto/response/UpdateNicknameResponse.java
@@ -1,0 +1,10 @@
+package com.bobeat.backend.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "닉네임 수정 응답 DTO")
+public record UpdateNicknameResponse(
+        @Schema(description = "수정된 닉네임")
+        String nickName
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/member/entity/SocialProvider.java
+++ b/src/main/java/com/bobeat/backend/domain/member/entity/SocialProvider.java
@@ -2,6 +2,5 @@ package com.bobeat.backend.domain.member.entity;
 
 public enum SocialProvider {
     KAKAO,
-    NAVER,
     GOOGLE
 }

--- a/src/main/java/com/bobeat/backend/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/bobeat/backend/domain/onboarding/controller/OnboardingController.java
@@ -1,0 +1,27 @@
+package com.bobeat.backend.domain.onboarding.controller;
+
+import com.bobeat.backend.domain.onboarding.dto.response.OnBoardingResult;
+import com.bobeat.backend.domain.onboarding.dto.request.OnboardingRequest;
+import com.bobeat.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Onboarding", description = "온보딩 관련 API")
+@RestController
+@RequestMapping("/api/v1/onboarding")
+public class OnboardingController {
+
+    @Operation(summary = "온보딩 결과 등록", description = "온보딩 결과인 혼밥 레벨을 등록합니다.")
+    @PostMapping
+    public ApiResponse<OnBoardingResult> submitOnboarding(
+            @Parameter(hidden = true) /*@AuthenticationPrincipal*/ Long memberId,
+            @RequestBody OnboardingRequest request
+    ) {
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/onboarding/dto/request/OnboardingAnswerDto.java
+++ b/src/main/java/com/bobeat/backend/domain/onboarding/dto/request/OnboardingAnswerDto.java
@@ -1,0 +1,12 @@
+package com.bobeat.backend.domain.onboarding.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "온보딩 질문 답변 DTO")
+public record OnboardingAnswerDto(
+        @Schema(description = "질문 순서 (1~5)")
+        int questionOrder,
+        @Schema(description = "선택한 옵션 순번 (1부터 시작)")
+        int selectedOption
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/onboarding/dto/request/OnboardingRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/onboarding/dto/request/OnboardingRequest.java
@@ -1,0 +1,11 @@
+package com.bobeat.backend.domain.onboarding.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "온보딩 결과 등록 요청 DTO")
+public record OnboardingRequest(
+        @Schema(description = "질문 답변 목록")
+        List<OnboardingAnswerDto> answers
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/onboarding/dto/response/OnBoardingResult.java
+++ b/src/main/java/com/bobeat/backend/domain/onboarding/dto/response/OnBoardingResult.java
@@ -1,0 +1,4 @@
+package com.bobeat.backend.domain.onboarding.dto.response;
+
+public record OnBoardingResult(int level) {
+}

--- a/src/main/java/com/bobeat/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/bobeat/backend/domain/report/controller/ReportController.java
@@ -1,0 +1,23 @@
+package com.bobeat.backend.domain.report.controller;
+
+import com.bobeat.backend.domain.report.dto.request.StoreReportRequest;
+import com.bobeat.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Report", description = "식당 제보 관련 API")
+@RestController
+@RequestMapping("/api/v1/report")
+public class ReportController {
+
+    @Operation(summary = "식당 제보 등록", description = "사용자가 새로운 식당을 제보합니다.")
+    @PostMapping
+    public ApiResponse<Void> reportStore(@RequestBody StoreReportRequest request) {
+        return ApiResponse.successOnly();
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/report/dto/request/StoreReportRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/report/dto/request/StoreReportRequest.java
@@ -1,0 +1,31 @@
+package com.bobeat.backend.domain.report.dto.request;
+
+import com.bobeat.backend.domain.store.entity.SeatType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "식당 제보 등록 요청 DTO")
+public record StoreReportRequest(
+        @Schema(description = "가게 위치", example = "서울 강남구 테헤란로 1길")
+        String location,
+        @Schema(description = "가게 이름")
+        String name,
+        @Schema(description = "좌석 형태")
+        List<SeatType> seatType,
+
+        // TODO: ENUM 생성 후 ENUM으로 변경
+        @Schema(description = "결제 방식", example = "[\"카운터 결제\"]")
+        List<String> paymentMethods,
+
+        // TODO: ENUM 생성 후 ENUM으로 변경
+        @Schema(description = "메뉴 카테고리", example = "[\"한식\"]")
+        List<String> menuCategories,
+
+        @Schema(description = "추천 메뉴")
+        String recommendedMenu,
+        @Schema(description = "식당을 추천하는 이유")
+        String reason,
+        @Schema(description = "제보한 회원 ID (선택 사항)")
+        Long memberId
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/controller/StoreController.java
+++ b/src/main/java/com/bobeat/backend/domain/store/controller/StoreController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
 
     @Operation(summary = "위치 기반 식당 검색", description = "현재 위치를 기반으로 식당을 검색하고 필터링합니다.")
-    @PostMapping("/api/stores")
+    @PostMapping
     public ApiResponse<CursorPageResponse<StoreSearchResponse>> searchRestaurants(
             @Valid CursorPaginationRequest pagination,
             @RequestBody @Valid StoreFilteringRequest filteringRequest,

--- a/src/main/java/com/bobeat/backend/domain/store/controller/StoreController.java
+++ b/src/main/java/com/bobeat/backend/domain/store/controller/StoreController.java
@@ -1,0 +1,54 @@
+package com.bobeat.backend.domain.store.controller;
+
+import com.bobeat.backend.domain.store.dto.request.EditProposalRequest;
+import com.bobeat.backend.domain.store.dto.request.StoreFilteringRequest;
+import com.bobeat.backend.domain.store.dto.request.StoreSort;
+import com.bobeat.backend.domain.store.dto.response.StoreDetailResponse;
+import com.bobeat.backend.domain.store.dto.response.StoreSearchResponse;
+import com.bobeat.backend.global.response.ApiResponse;
+import com.bobeat.backend.global.response.CursorPageResponse;
+import com.bobeat.backend.global.response.CursorPaginationRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Store", description = "가게(식당) 관련 API")
+@RestController
+@RequestMapping("/api/v1/restaurants")
+public class StoreController {
+
+    @Operation(summary = "위치 기반 식당 검색", description = "현재 위치를 기반으로 식당을 검색하고 필터링합니다.")
+    @PostMapping("/api/stores")
+    public ApiResponse<CursorPageResponse<StoreSearchResponse>> searchRestaurants(
+            @Valid CursorPaginationRequest pagination,
+            @RequestBody @Valid StoreFilteringRequest filteringRequest,
+            @Parameter(description = "정렬 기준", example = "DISTANCE")
+            @RequestParam(defaultValue = "DISTANCE", required = false) StoreSort sortBy) {
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "식당 상세 정보 조회", description = "특정 식당의 상세 정보를 조회합니다.")
+    @GetMapping("/{restaurantId}")
+    public ApiResponse<StoreDetailResponse> getRestaurantDetails(
+            @Parameter(description = "식당 ID") @PathVariable Long restaurantId
+    ) {
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "정보 수정 제안", description = "식당 정보 수정을 제안합니다.")
+    @PostMapping("/{restaurantId}/proposals")
+    public ApiResponse<Void> proposeEdit(
+            @Parameter(description = "식당 ID") @PathVariable Long restaurantId,
+            @RequestBody EditProposalRequest request
+    ) {
+        return ApiResponse.successOnly();
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/request/EditProposalRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/request/EditProposalRequest.java
@@ -1,0 +1,11 @@
+package com.bobeat.backend.domain.store.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// TODO: 디자인 시안 안 나옴
+@Schema(description = "정보 수정 제안 요청 DTO")
+public record EditProposalRequest(
+        @Schema(description = "제안 내용")
+        String content
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreFilteringRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreFilteringRequest.java
@@ -1,0 +1,54 @@
+package com.bobeat.backend.domain.store.dto.request;
+
+import com.bobeat.backend.domain.store.entity.SeatType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record StoreFilteringRequest(
+        @Schema(description = "박스 좌상단 위도", example = "37.58")
+        @NotNull
+        Double nwLat,
+
+        @Schema(description = "박스 좌상단 경도", example = "127.0")
+        @NotNull
+        Double nwLon,
+
+        @Schema(description = "박스 우하단 위도", example = "37.55")
+        @NotNull
+        Double seLat,
+
+        @Schema(description = "박스 우하단 경도", example = "127.05")
+        @NotNull
+        Double seLon,
+
+        @Schema(description = "박스 중심점 위도", example = "37.56")
+        @NotNull
+        Double centerLat,
+
+        @Schema(description = "박스 중심점 경도", example = "127.02")
+        @NotNull
+        Double centerLon,
+
+        @Schema(description = "최소 메뉴 가격", example = "10000")
+        Integer priceMin,
+
+        @Schema(description = "최대 메뉴 가격", example = "30000")
+        Integer priceMax,
+
+        @Schema(description = "혼밥 레벨 (1~5)", example = "3")
+        @NotNull
+        Integer level,
+
+        @Schema(description = "좌석 형태", example = "[\"FOR_ONE\", \"BAR\"]")
+        List<SeatType> seatType,
+
+        // TODO: ENUM 생성시 변경
+        @Schema(description = "결제 방식", example = "[\"CARD\", \"ZERO_PAY\"]")
+        List<String> paymentMethods,
+
+        // TODO: ENUM 생성시 변경
+        @Schema(description = "메뉴 카테고리", example = "[\"korean\", \"japanese\"]")
+        List<String> menuCategories
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreSort.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreSort.java
@@ -1,0 +1,5 @@
+package com.bobeat.backend.domain.store.dto.request;
+
+public enum StoreSort {
+    DISTANCE
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/MenuDto.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/MenuDto.java
@@ -1,0 +1,14 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "메뉴 정보 DTO")
+public record MenuDto(
+        @Schema(description = "메뉴 이름")
+        String name,
+        @Schema(description = "메뉴 가격")
+        int price,
+        @Schema(description = "대표 메뉴 여부")
+        boolean isRepresentative
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/PriceComparisonAverage.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/PriceComparisonAverage.java
@@ -1,0 +1,18 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public enum PriceComparisonAverage {
+    MUCH_MORE_EXPENSIVE("훨씬 비쌈"),
+    MORE_EXPENSIVE("비쌈"),
+    SIMILAR("평균과 비슷함"),
+    CHEAPER("쌈"),
+    MUCH_CHEAPER("훨씬 쌈");
+
+    private final String description;
+
+    PriceComparisonAverage(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/PriceComparisonDto.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/PriceComparisonDto.java
@@ -1,0 +1,16 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가격 비교 정보 DTO")
+public record PriceComparisonDto(
+        @Schema(description = "대표 메뉴 가격(원)")
+        int representativeMenuPrice,
+        @Schema(description = "해당 지역 평균 점심값(원)")
+        int averageLunchPrice,
+        @Schema(description = "지역 평균 대비 대표 메뉴 가격 차이")
+        int averagePriceDifference,
+        @Schema(description = "지역 평균 대비 대표 메뉴 가격 정보")
+        PriceComparisonAverage comparisonAverage
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/SeatInfoDto.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/SeatInfoDto.java
@@ -1,0 +1,16 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좌석 정보 DTO")
+public record SeatInfoDto(
+        @Schema(description = "전체 좌석 수")
+        int total,
+        @Schema(description = "1인석 수")
+        int onePerson,
+        @Schema(description = "바 좌석 수")
+        int bar,
+        @Schema(description = "2인석 수")
+        int twoPerson
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/StoreDetailResponse.java
@@ -1,0 +1,31 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "가게 상세 정보 조회 응답 DTO")
+public record StoreDetailResponse(
+        @Schema(description = "가게 ID")
+        Long restaurantId,
+        @Schema(description = "가게 이름")
+        String name,
+        @Schema(description = "가게 대표 이미지 URL 목록")
+        List<String> thumbnailUrls,
+        @Schema(description = "혼밥 레벨")
+        int level,
+        @Schema(description = "카테고리")
+        String category,
+        @Schema(description = "주소")
+        String address,
+        @Schema(description = "전화번호")
+        String phone,
+        @Schema(description = "메뉴 목록")
+        List<MenuDto> menus,
+        @Schema(description = "좌석 정보")
+        SeatInfoDto seatInfo,
+        @Schema(description = "가격 비교 정보")
+        PriceComparisonDto priceComparison,
+        @Schema(description = "좌석 이미지 URL 목록")
+        List<String> seatImages
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/StoreSearchResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/StoreSearchResponse.java
@@ -1,0 +1,13 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "위치 기반 가게 검색 응답 DTO")
+public record StoreSearchResponse(
+        @Schema(description = "가게 목록")
+        List<StoreSearchResultDto> items,
+        @Schema(description = "다음 페이지 조회용 커서")
+        String nextCursor
+) {
+}

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/StoreSearchResultDto.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/StoreSearchResultDto.java
@@ -1,0 +1,27 @@
+package com.bobeat.backend.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "위치 기반 가게 검색 결과 항목 DTO")
+public record StoreSearchResultDto(
+        @Schema(description = "가게 ID")
+        Long restaurantId,
+        @Schema(description = "가게 이름")
+        String name,
+        @Schema(description = "가게 대표 이미지 URL")
+        String thumbnailUrl,
+        @Schema(description = "대표 메뉴")
+        String representativeMenu,
+        @Schema(description = "대표 메뉴 가격(원)")
+        int menuPrice,
+        @Schema(description = "현재 위치로부터 거리(m)")
+        int distance,
+        @Schema(description = "지원 좌석 형태")
+        List<String> seatTypes,
+        @Schema(description = "메뉴 카테고리")
+        List<String> menuCategories,
+        @Schema(description = "사용자가 저장한 가게 여부")
+        boolean isSaved
+) {
+}

--- a/src/main/java/com/bobeat/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/bobeat/backend/global/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("북스타 API 명세서")
+                        .title("밥잇 API 명세서")
                         .description("작성중입니다")
                         .version("1.0.0")
                 )

--- a/src/main/java/com/bobeat/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/bobeat/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,53 @@
+package com.bobeat.backend.global.config;
+
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.properties.SwaggerUiConfigParameters;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("북스타 API 명세서")
+                        .description("작성중입니다")
+                        .version("1.0.0")
+                )
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth")) // SecurityRequirement 추가
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .name("BearerAuth")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT"))); // JWT 인증 적용
+    }
+
+    // Swagger UI의 동작을 제어
+    @Bean
+    public SwaggerUiConfigParameters swaggerUiConfigParameters(SwaggerUiConfigProperties swaggerUiConfigProperties) {
+        SwaggerUiConfigParameters parameters = new SwaggerUiConfigParameters(swaggerUiConfigProperties);
+
+        // 같은 api 접두사 내에 정렬
+        parameters.setOperationsSorter("method");
+
+        // api 별로 정렬
+        parameters.setTagsSorter("alpha");
+
+        // 검색창 활성화
+        parameters.setFilter("true");
+
+        // 브라우저 닫더라도 토큰 유효하게
+        parameters.setPersistAuthorization(true);
+        parameters.setDocExpansion("none");
+
+        return parameters;
+    }
+}

--- a/src/main/java/com/bobeat/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/bobeat/backend/global/exception/ErrorResponse.java
@@ -1,23 +1,12 @@
 package com.bobeat.backend.global.exception;
 
-import lombok.Builder;
+public record ErrorResponse(String code, String message) {
 
-@Builder
-public record ErrorResponse(int status, String code, String message) {
-
-    public static ErrorResponse of(ErrorCode errorCode) {
-        return ErrorResponse.builder()
-                .status(errorCode.getHttpStatus().value())
-                .code(errorCode.getCode())
-                .message(errorCode.getMessage())
-                .build();
+    public ErrorResponse(ErrorCode errorCode) {
+        this(errorCode.getCode(), errorCode.getMessage());
     }
 
-    public static ErrorResponse of(String message, ErrorCode errorCode) {
-        return ErrorResponse.builder()
-                .status(errorCode.getHttpStatus().value())
-                .code(errorCode.getCode())
-                .message(message)
-                .build();
+    public ErrorResponse(ErrorCode errorCode, String message) {
+        this(errorCode.getCode(), message);
     }
 }

--- a/src/main/java/com/bobeat/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bobeat/backend/global/exception/GlobalExceptionHandler.java
@@ -12,17 +12,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ApiResponse<?> handleException(RuntimeException e) {
-        return handleException(e, ErrorResponse.of(ErrorCode.INTERNAL_SERVER));
+        return handleException(e, new ErrorResponse(ErrorCode.INTERNAL_SERVER));
     }
 
     @ExceptionHandler(CustomException.class)
     public ApiResponse<?> handleCustomException(CustomException e) {
-        return handleException(e, ErrorResponse.of(e.getMessage(), e.getErrorCode()));
+        return handleException(e, new ErrorResponse(e.getErrorCode(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ApiResponse<?> handleValidateException(MethodArgumentNotValidException e){
-        return handleException(e, ErrorResponse.of(ErrorCode.BAD_REQUEST));
+        return handleException(e, new ErrorResponse(ErrorCode.BAD_REQUEST));
     }
 
     public ApiResponse<?> handleException(Exception e, ErrorResponse errorResponse) {

--- a/src/main/java/com/bobeat/backend/global/response/ApiResponse.java
+++ b/src/main/java/com/bobeat/backend/global/response/ApiResponse.java
@@ -11,21 +11,19 @@ import lombok.Getter;
 @Getter
 public class ApiResponse<T> {
 
-    private final boolean success;
-
     private final T response;
 
     private final ErrorResponse errorResponse;
 
     public static <T> ApiResponse<T> success(T response) {
-        return new ApiResponse<>(true, response, null);
+        return new ApiResponse<>(response, null);
     }
 
     public static ApiResponse<?> error(ErrorResponse errorResponse) {
-        return new ApiResponse<>(false, null, errorResponse);
+        return new ApiResponse<>(null, errorResponse);
     }
 
     public static ApiResponse<Void> successOnly() {
-        return new ApiResponse<>(true, null, null);
+        return new ApiResponse<>(null, null);
     }
 }

--- a/src/main/java/com/bobeat/backend/global/response/CursorPageResponse.java
+++ b/src/main/java/com/bobeat/backend/global/response/CursorPageResponse.java
@@ -1,0 +1,49 @@
+package com.bobeat.backend.global.response;
+
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.ToLongFunction;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 커서 기반 페이지네이션 응답을 위한 범용 클래스입니다.
+ * 이 클래스는 단일 ID 기반의 커서를 사용하여 다음 페이지를 조회할 때 사용됩니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public class CursorPageResponse<T> {
+
+    private final List<T> data;
+    private final Long nextCursor;
+    private final Boolean hasNext;
+
+    /**
+     * Repository에서 pageSize + 1만큼 조회한 데이터 리스트를 받아
+     * 다음 페이지 유무(hasNext)와 다음 커서(nextCursor)를 계산하여 응답 객체를 생성합니다.
+     *
+     * @param data        Repository에서 조회된 데이터 리스트 (pageSize + 1 크기)
+     * @param pageSize    클라이언트에게 반환할 실제 페이지 크기
+     * @param idExtractor 데이터 요소에서 Long 타입의 ID(커서)를 추출하는 함수
+     * @param <T>         데이터 요소의 타입
+     * @return 계산된 페이지네이션 정보가 포함된 응답 객체
+     */
+    public static <T> CursorPageResponse<T> of(List<T> data, int pageSize, ToLongFunction<T> idExtractor) {
+        boolean hasNext = data.size() > pageSize;
+        long nextCursor = -1L;
+
+        if (hasNext) {
+            T lastReponse = data.get(pageSize - 1);
+            nextCursor = idExtractor.applyAsLong(lastReponse);
+
+            data = data.subList(0, pageSize);
+        }
+
+        return new CursorPageResponse<>(data, nextCursor, hasNext);
+    }
+
+    public static <T> CursorPageResponse<T> empty() {
+        return new CursorPageResponse<>(Collections.emptyList(), -1L, false);
+    }
+}

--- a/src/main/java/com/bobeat/backend/global/response/CursorPaginationRequest.java
+++ b/src/main/java/com/bobeat/backend/global/response/CursorPaginationRequest.java
@@ -1,0 +1,13 @@
+package com.bobeat.backend.global.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record CursorPaginationRequest(
+        @Schema(description = "한 번에 조회할 최대 항목 수")
+        @NotNull
+        int limit,
+        @Schema(description = "지난 응답 때 마지막 커서ID")
+        String lastKnown
+) {
+}

--- a/src/test/java/com/bobeat/backend/global/api/ApiControllerIntegrationTest.java
+++ b/src/test/java/com/bobeat/backend/global/api/ApiControllerIntegrationTest.java
@@ -21,7 +21,6 @@ class ApiControllerIntegrationTest {
     void 전역_응답_값을_사용한다() throws Exception {
         mockMvc.perform(get("/test/success"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.response.message").value("응답 값"))
             .andExpect(jsonPath("$.error").doesNotExist());
     }
@@ -30,7 +29,6 @@ class ApiControllerIntegrationTest {
     void 전역_예외_값을_확인한다() throws Exception {
         mockMvc.perform(get("/test/error"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.response").doesNotExist())
             .andExpect(jsonPath("$.errorResponse.code").value("G500"))
             .andExpect(jsonPath("$.errorResponse.message").value("서버 내부에서 에러가 발생하였습니다"));
@@ -40,7 +38,6 @@ class ApiControllerIntegrationTest {
     void 전역_예외만_생성_할_수_있다() throws Exception {
         mockMvc.perform(get("/test/success-only"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data").doesNotExist())
             .andExpect(jsonPath("$.error").doesNotExist());
     }
@@ -49,7 +46,6 @@ class ApiControllerIntegrationTest {
     void 커스텀_예외를_발생시킨다() throws Exception {
         mockMvc.perform(get("/test/custom-error"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.response").doesNotExist())
                 .andExpect(jsonPath("$.errorResponse.code").value("G500"))
                 .andExpect(jsonPath("$.errorResponse.message").value("서버 내부에서 에러가 발생하였습니다"));
@@ -59,7 +55,6 @@ class ApiControllerIntegrationTest {
     void 커스텀_예외를_메세지와_함께_발생시킨다() throws Exception {
         mockMvc.perform(get("/test/custom-error/message"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.response").doesNotExist())
                 .andExpect(jsonPath("$.errorResponse.code").value("G500"))
                 .andExpect(jsonPath("$.errorResponse.message").value("허용되지 않은 API입니다"));

--- a/src/test/java/com/bobeat/backend/global/api/TestController.java
+++ b/src/test/java/com/bobeat/backend/global/api/TestController.java
@@ -1,9 +1,7 @@
 package com.bobeat.backend.global.api;
 
-import com.bobeat.backend.global.exception.ErrorResponse;
 import com.bobeat.backend.global.response.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController


### PR DESCRIPTION
## 🔖 Title
[Common][Feat] 전체 API 엔드포인트 정의

### 1. Summary 📝
- 전체 API 엔드포인트 정의
- 금요일까지 엔드포인트를 정의해야 하니 디테일을 챙기기보다는 1차 완성 느낌으로 구현하였습니다. 빠르게 머지하고 각자 리팩토링하는 방식으로 하면 될 것 같습니다

### 2. Related Issue 🔗
- Close #10

### 3. Domain
- [x] Common 

### 4. Type
- [x] Feature ✨


### 5. Changes(detail)
1. 공통 커서 리스폰스 정의
2. 스프링 다운그레이드
3. 공통 응답에서 상태값 제거
4. 전체 API 엔드포인트 정의


### 코드 리뷰 주안점: 
1. GET 가게 정보 조회 파라미터가 너무 많아 -> POST로 바꾸어 request body를 받도록 하였습니다

스웨거 접속 링크: http://localhost:8080/swagger-ui/index.htm

<img width="1142" height="647" alt="image" src="https://github.com/user-attachments/assets/38949900-8494-420f-ae4a-efdf220bacb1" />

