### PR TITLE
[Review][Feat] 리뷰 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // test
+    testRuntimeOnly 'com.h2database:h2'
+    testImplementation 'org.testcontainers:postgresql:1.19.0'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
 }
 
 

--- a/src/main/java/com/bobeat/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/bobeat/backend/domain/member/entity/Member.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +20,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class Member extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/bobeat/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/bobeat/backend/domain/member/entity/Member.java
@@ -37,4 +37,8 @@ public class Member extends BaseTimeEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+    
+    public boolean isOwner(Long memberId) {
+        return this.id.equals(memberId);
+    }
 }

--- a/src/main/java/com/bobeat/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/bobeat/backend/domain/review/controller/ReviewController.java
@@ -1,0 +1,84 @@
+package com.bobeat.backend.domain.review.controller;
+
+import com.bobeat.backend.domain.review.dto.request.CreateReviewRequest;
+import com.bobeat.backend.domain.review.dto.request.UpdateReviewRequest;
+import com.bobeat.backend.domain.review.dto.response.ReviewResponse;
+import com.bobeat.backend.domain.review.service.ReviewService;
+import com.bobeat.backend.global.request.CursorPaginationRequest;
+import com.bobeat.backend.global.response.ApiResponse;
+import com.bobeat.backend.global.response.CursorPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Review", description = "리뷰 관련 API")
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+    
+    private final ReviewService reviewService;
+    
+    @Operation(summary = "리뷰 작성", description = "특정 가게에 리뷰를 작성합니다.")
+    @PostMapping
+    public ApiResponse<ReviewResponse> createReview(
+            @Parameter(description = "회원 ID", example = "1") @RequestHeader("Member-Id") Long memberId,
+            @RequestBody @Valid CreateReviewRequest request
+    ) {
+        ReviewResponse response = reviewService.createReview(memberId, request);
+        return ApiResponse.success(response);
+    }
+    
+    @Operation(summary = "가게별 리뷰 목록 조회", description = "특정 가게의 리뷰 목록을 커서 기반으로 조회합니다.")
+    @GetMapping("/stores/{storeId}")
+    public ApiResponse<CursorPageResponse<ReviewResponse>> getReviewsByStore(
+            @Parameter(description = "가게 ID", example = "1") @PathVariable Long storeId,
+            @ModelAttribute @Valid CursorPaginationRequest request
+    ) {
+        CursorPageResponse<ReviewResponse> response = reviewService.getReviewsByStore(storeId, request);
+        return ApiResponse.success(response);
+    }
+    
+    @Operation(summary = "내 리뷰 목록 조회", description = "로그인한 사용자의 리뷰 목록을 커서 기반으로 조회합니다.")
+    @GetMapping("/my")
+    public ApiResponse<CursorPageResponse<ReviewResponse>> getMyReviews(
+            @Parameter(description = "회원 ID", example = "1") @RequestHeader("Member-Id") Long memberId,
+            @ModelAttribute @Valid CursorPaginationRequest request
+    ) {
+        CursorPageResponse<ReviewResponse> response = reviewService.getMyReviews(memberId, request);
+        return ApiResponse.success(response);
+    }
+    
+    @Operation(summary = "리뷰 상세 조회", description = "특정 리뷰의 상세 정보를 조회합니다.")
+    @GetMapping("/{reviewId}")
+    public ApiResponse<ReviewResponse> getReviewById(
+            @Parameter(description = "리뷰 ID", example = "1") @PathVariable Long reviewId
+    ) {
+        ReviewResponse response = reviewService.getReviewById(reviewId);
+        return ApiResponse.success(response);
+    }
+    
+    @Operation(summary = "리뷰 수정", description = "작성한 리뷰를 수정합니다.")
+    @PutMapping("/{reviewId}")
+    public ApiResponse<ReviewResponse> updateReview(
+            @Parameter(description = "회원 ID", example = "1") @RequestHeader("Member-Id") Long memberId,
+            @Parameter(description = "리뷰 ID", example = "1") @PathVariable Long reviewId,
+            @RequestBody @Valid UpdateReviewRequest request
+    ) {
+        ReviewResponse response = reviewService.updateReview(memberId, reviewId, request);
+        return ApiResponse.success(response);
+    }
+    
+    @Operation(summary = "리뷰 삭제", description = "작성한 리뷰를 삭제합니다.")
+    @DeleteMapping("/{reviewId}")
+    public ApiResponse<Void> deleteReview(
+            @Parameter(description = "회원 ID", example = "1") @RequestHeader("Member-Id") Long memberId,
+            @Parameter(description = "리뷰 ID", example = "1") @PathVariable Long reviewId
+    ) {
+        reviewService.deleteReview(memberId, reviewId);
+        return ApiResponse.successOnly();
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/review/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/request/CreateReviewRequest.java
@@ -5,11 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Getter
 @NoArgsConstructor
+@Data
 @Schema(description = "리뷰 작성 요청")
 public class CreateReviewRequest {
 

--- a/src/main/java/com/bobeat/backend/domain/review/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/request/CreateReviewRequest.java
@@ -1,0 +1,26 @@
+package com.bobeat.backend.domain.review.dto.request;
+
+import com.bobeat.backend.domain.review.entity.ReviewKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "리뷰 작성 요청")
+public class CreateReviewRequest {
+
+    @NotNull(message = "가게 ID는 필수입니다")
+    @Schema(description = "가게 ID", example = "1")
+    private Long storeId;
+
+    @NotBlank(message = "리뷰 내용은 필수입니다")
+    @Schema(description = "리뷰 내용", example = "맛있고 분위기도 좋아요!")
+    private String content;
+
+    @Schema(description = "리뷰 키워드 목록")
+    private List<ReviewKeyword> keywords;
+}

--- a/src/main/java/com/bobeat/backend/domain/review/dto/request/UpdateReviewRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/request/UpdateReviewRequest.java
@@ -4,11 +4,12 @@ import com.bobeat.backend.domain.review.entity.ReviewKeyword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Getter
+
 @NoArgsConstructor
+@Data
 @Schema(description = "리뷰 수정 요청")
 public class UpdateReviewRequest {
 

--- a/src/main/java/com/bobeat/backend/domain/review/dto/request/UpdateReviewRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/request/UpdateReviewRequest.java
@@ -1,0 +1,21 @@
+package com.bobeat.backend.domain.review.dto.request;
+
+import com.bobeat.backend.domain.review.entity.ReviewKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "리뷰 수정 요청")
+public class UpdateReviewRequest {
+
+    @NotBlank(message = "리뷰 내용은 필수입니다")
+    @Schema(description = "리뷰 내용", example = "맛있고 분위기도 좋아요!")
+    private String content;
+
+    @Schema(description = "리뷰 키워드 목록")
+    private List<ReviewKeyword> keywords;
+}

--- a/src/main/java/com/bobeat/backend/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/response/ReviewResponse.java
@@ -1,0 +1,62 @@
+package com.bobeat.backend.domain.review.dto.response;
+
+import com.bobeat.backend.domain.review.entity.ReviewKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "리뷰 응답")
+public class ReviewResponse {
+    
+    @Schema(description = "리뷰 ID", example = "1")
+    private Long id;
+    
+    @Schema(description = "리뷰 내용", example = "맛있고 분위기도 좋아요!")
+    private String content;
+    
+    @Schema(description = "작성자 정보")
+    private ReviewerInfo reviewer;
+    
+    @Schema(description = "리뷰 키워드 목록")
+    private List<ReviewKeyword> keywords;
+    
+    @Schema(description = "작성일시")
+    private LocalDateTime createdAt;
+    
+    @Schema(description = "수정일시")
+    private LocalDateTime updatedAt;
+    
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "리뷰 작성자 정보")
+    public static class ReviewerInfo {
+        @Schema(description = "사용자 ID", example = "1")
+        private Long id;
+        
+        @Schema(description = "닉네임", example = "홍길동")
+        private String nickname;
+        
+        @Schema(description = "프로필 이미지 URL")
+        private String profileImageUrl;
+    }
+    
+    public static ReviewResponse from(com.bobeat.backend.domain.review.entity.Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getContent(),
+                new ReviewerInfo(
+                        review.getMember().getId(),
+                        review.getMember().getNickname(),
+                        review.getMember().getProfileImageUrl()
+                ),
+                review.getKeywords(),
+                review.getCreatedAt(),
+                review.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/review/dto/response/StoreInfo.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/response/StoreInfo.java
@@ -1,0 +1,20 @@
+package com.bobeat.backend.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "가게 정보")
+public class StoreInfo {
+    
+    @Schema(description = "가게 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "가게명", example = "맛있는 식당")
+    private String name;
+
+    @Schema(description = "가게 이미지 URL")
+    private String mainImageUrl;
+}

--- a/src/main/java/com/bobeat/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/bobeat/backend/domain/review/entity/Review.java
@@ -5,6 +5,8 @@ import com.bobeat.backend.domain.member.entity.Member;
 import com.bobeat.backend.domain.store.entity.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -46,6 +48,7 @@ public class Review extends BaseTimeEntity {
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(columnDefinition = "text[]")
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     private List<ReviewKeyword> keywords = new ArrayList<>();
     

--- a/src/main/java/com/bobeat/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/bobeat/backend/domain/review/entity/Review.java
@@ -3,7 +3,7 @@ package com.bobeat.backend.domain.review.entity;
 import com.bobeat.backend.domain.common.BaseTimeEntity;
 import com.bobeat.backend.domain.member.entity.Member;
 import com.bobeat.backend.domain.store.entity.Store;
-import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -12,9 +12,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +26,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "review")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Review extends BaseTimeEntity {
 
     @Id
@@ -29,7 +35,6 @@ public class Review extends BaseTimeEntity {
     private Long id;
 
     private String content;
-    private Double rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -39,6 +44,17 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "store_id")
     private Store store;
 
-    @ElementCollection
-    private List<String> imageUrls = new ArrayList<>();
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(columnDefinition = "text[]")
+    @Builder.Default
+    private List<ReviewKeyword> keywords = new ArrayList<>();
+    
+    public void update(String content, List<ReviewKeyword> keywords) {
+        this.content = content;
+        this.keywords = keywords != null ? keywords : new ArrayList<>();
+    }
+    
+    public boolean isOwnedBy(Long memberId) {
+        return this.member.getId().equals(memberId);
+    }
 }

--- a/src/main/java/com/bobeat/backend/domain/review/entity/ReviewKeyword.java
+++ b/src/main/java/com/bobeat/backend/domain/review/entity/ReviewKeyword.java
@@ -1,0 +1,17 @@
+package com.bobeat.backend.domain.review.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewKeyword {
+    
+    BEST_TASTE("맛은 최고"),
+    GOOD_FOR_SOLO("혼밥 대박"),
+    KIND_SERVICE("친절한 응대"),
+    NICE_STAFF("재밌던 직원"),
+    OPEN_ATMOSPHERE("보통의 맛");
+    
+    private final String displayName;
+}

--- a/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,16 @@
+package com.bobeat.backend.domain.review.repository;
+
+import com.bobeat.backend.domain.review.entity.Review;
+import com.bobeat.backend.global.exception.CustomException;
+import com.bobeat.backend.global.exception.ErrorCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
+
+    boolean existsByMemberIdAndStoreId(Long memberId, Long storeId);
+
+    default Review findByIdOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.bobeat.backend.domain.review.repository;
+
+import com.bobeat.backend.domain.review.entity.Review;
+import com.bobeat.backend.global.request.CursorPaginationRequest;
+
+import java.util.List;
+
+public interface ReviewRepositoryCustom {
+    
+    List<Review> findByStoreIdWithCursor(Long storeId, CursorPaginationRequest request);
+    
+    List<Review> findByMemberIdWithCursor(Long memberId, CursorPaginationRequest request);
+}

--- a/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryImpl.java
@@ -23,7 +23,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
         if (request.lastKnown() != null) {
             Long cursor = Long.parseLong(request.lastKnown());
-            builder.and(review.id.loe(cursor));
+            builder.and(review.id.lt(cursor));
         }
 
         return queryFactory
@@ -42,7 +42,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
         if (request.lastKnown() != null) {
             Long cursor = Long.parseLong(request.lastKnown());
-            builder.and(review.id.loe(cursor));
+            builder.and(review.id.lt(cursor));
         }
 
         return queryFactory

--- a/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.bobeat.backend.domain.review.repository;
+
+import static com.bobeat.backend.domain.review.entity.QReview.review;
+
+import com.bobeat.backend.domain.review.entity.Review;
+import com.bobeat.backend.global.request.CursorPaginationRequest;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Review> findByStoreIdWithCursor(Long storeId, CursorPaginationRequest request) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(review.store.id.eq(storeId));
+
+        if (request.lastKnown() != null) {
+            Long cursor = Long.parseLong(request.lastKnown());
+            builder.and(review.id.loe(cursor));
+        }
+
+        return queryFactory
+                .selectFrom(review)
+                .leftJoin(review.member).fetchJoin()
+                .where(builder)
+                .orderBy(review.id.desc())
+                .limit(request.limit() + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<Review> findByMemberIdWithCursor(Long memberId, CursorPaginationRequest request) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(review.member.id.eq(memberId));
+
+        if (request.lastKnown() != null) {
+            Long cursor = Long.parseLong(request.lastKnown());
+            builder.and(review.id.loe(cursor));
+        }
+
+        return queryFactory
+                .selectFrom(review)
+                .leftJoin(review.store).fetchJoin()
+                .where(builder)
+                .orderBy(review.id.desc())
+                .limit(request.limit() + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/bobeat/backend/domain/review/service/ReviewService.java
@@ -1,0 +1,110 @@
+package com.bobeat.backend.domain.review.service;
+
+import com.bobeat.backend.domain.member.entity.Member;
+import com.bobeat.backend.domain.member.repository.MemberRepository;
+import com.bobeat.backend.domain.review.dto.request.CreateReviewRequest;
+import com.bobeat.backend.domain.review.dto.request.UpdateReviewRequest;
+import com.bobeat.backend.domain.review.dto.response.ReviewResponse;
+import com.bobeat.backend.domain.review.dto.response.StoreInfo;
+import com.bobeat.backend.domain.review.entity.Review;
+import com.bobeat.backend.domain.review.repository.ReviewRepository;
+import com.bobeat.backend.domain.store.entity.Store;
+import com.bobeat.backend.domain.store.repository.StoreRepository;
+import com.bobeat.backend.global.exception.CustomException;
+import com.bobeat.backend.global.exception.ErrorCode;
+import com.bobeat.backend.global.request.CursorPaginationRequest;
+import com.bobeat.backend.global.response.CursorPageResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public ReviewResponse createReview(Long memberId, CreateReviewRequest request) {
+        Member member = memberRepository.findByIdOrElseThrow(memberId);
+        Store store = storeRepository.findByIdOrThrow(request.getStoreId());
+
+        if (reviewRepository.existsByMemberIdAndStoreId(memberId, request.getStoreId())) {
+            throw new CustomException(ErrorCode.REVIEW_ALREADY_EXISTS);
+        }
+
+        Review review = Review.builder()
+                .content(request.getContent())
+                .member(member)
+                .store(store)
+                .keywords(request.getKeywords())
+                .build();
+
+        Review savedReview = reviewRepository.save(review);
+        return ReviewResponse.from(savedReview);
+    }
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<ReviewResponse> getReviewsByStore(Long storeId, CursorPaginationRequest request) {
+        Store store = storeRepository.findByIdOrThrow(storeId);
+
+        List<Review> reviews = reviewRepository.findByStoreIdWithCursor(storeId, request);
+
+        StoreInfo metadata = new StoreInfo(
+                store.getId(),
+                store.getName(),
+                store.getMainImageUrl()
+        );
+
+        return CursorPageResponse.of(
+                reviews.stream().map(ReviewResponse::from).toList(),
+                request.limit(),
+                ReviewResponse::getId,
+                metadata
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<ReviewResponse> getMyReviews(Long memberId, CursorPaginationRequest request) {
+        memberRepository.findByIdOrElseThrow(memberId);
+
+        List<Review> reviews = reviewRepository.findByMemberIdWithCursor(memberId, request);
+
+        return CursorPageResponse.of(
+                reviews.stream().map(ReviewResponse::from).toList(),
+                request.limit(),
+                ReviewResponse::getId);
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewResponse getReviewById(Long reviewId) {
+        Review review = reviewRepository.findByIdOrThrow(reviewId);
+        return ReviewResponse.from(review);
+    }
+
+    @Transactional
+    public ReviewResponse updateReview(Long memberId, Long reviewId, UpdateReviewRequest request) {
+        Review review = reviewRepository.findByIdOrThrow(reviewId);
+
+        if (!review.isOwnedBy(memberId)) {
+            throw new CustomException(ErrorCode.REVIEW_ACCESS_DENIED);
+        }
+
+        review.update(request.getContent(), request.getKeywords());
+        return ReviewResponse.from(review);
+    }
+
+    @Transactional
+    public void deleteReview(Long memberId, Long reviewId) {
+        Review review = reviewRepository.findByIdOrThrow(reviewId);
+
+        if (!review.isOwnedBy(memberId)) {
+            throw new CustomException(ErrorCode.REVIEW_ACCESS_DENIED);
+        }
+
+        reviewRepository.delete(review);
+    }
+}

--- a/src/main/java/com/bobeat/backend/domain/store/entity/HONBOB_LEVEL.java
+++ b/src/main/java/com/bobeat/backend/domain/store/entity/HONBOB_LEVEL.java
@@ -1,5 +1,0 @@
-package com.bobeat.backend.domain.store.entity;
-
-public enum HONBOB_LEVEL {
-    ONE,TWO,THREE,FOUR,FIVE
-}

--- a/src/main/java/com/bobeat/backend/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/bobeat/backend/domain/store/repository/StoreRepository.java
@@ -1,8 +1,14 @@
 package com.bobeat.backend.domain.store.repository;
 
 import com.bobeat.backend.domain.store.entity.Store;
+import com.bobeat.backend.global.exception.CustomException;
+import com.bobeat.backend.global.exception.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreRepositoryCustom {
+
+    default Store findByIdOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/bobeat/backend/domain/store/service/StoreService.java
+++ b/src/main/java/com/bobeat/backend/domain/store/service/StoreService.java
@@ -28,7 +28,8 @@ public class StoreService {
         return new CursorPageResponse<>(
                 storeSearchResponses,
                 storeCursorPageResponse.getNextCursor(),
-                storeCursorPageResponse.getHasNext()
+                storeCursorPageResponse.getHasNext(),
+                storeCursorPageResponse.getMetadata()
         );
     }
 

--- a/src/main/java/com/bobeat/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/bobeat/backend/global/exception/ErrorCode.java
@@ -17,7 +17,15 @@ public enum ErrorCode {
     // 회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "회원을 찾을 수 없습니다."),
     INVALID_LEVEL_VALUE(HttpStatus.BAD_REQUEST, "M002", "유효하지 않은 레벨 값입니다."),
-    INVALID_ONBOARDING_QUESTION(HttpStatus.BAD_REQUEST, "M003", "유효하지 않은 온보딩 질문 또는 옵션입니다.");
+    INVALID_ONBOARDING_QUESTION(HttpStatus.BAD_REQUEST, "M003", "유효하지 않은 온보딩 질문 또는 옵션입니다."),
+    
+    // 가게
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "가게를 찾을 수 없습니다."),
+    
+    // 리뷰
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "R002", "이미 해당 가게에 리뷰를 작성했습니다."),
+    REVIEW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "R003", "리뷰에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/bobeat/backend/global/response/CursorPageResponse.java
+++ b/src/main/java/com/bobeat/backend/global/response/CursorPageResponse.java
@@ -19,6 +19,7 @@ public class CursorPageResponse<T> {
     private final List<T> data;
     private final Long nextCursor;
     private final Boolean hasNext;
+    private final Object metadata;
 
     /**
      * Repository에서 pageSize + 1만큼 조회한 데이터 리스트를 받아
@@ -31,6 +32,14 @@ public class CursorPageResponse<T> {
      * @return 계산된 페이지네이션 정보가 포함된 응답 객체
      */
     public static <T> CursorPageResponse<T> of(List<T> data, int pageSize, ToLongFunction<T> idExtractor) {
+        return of(data, pageSize, idExtractor, null);
+    }
+
+    /**
+     * +)
+     * @param metadata    추가 메타데이터 객체
+     */
+    public static <T> CursorPageResponse<T> of(List<T> data, int pageSize, ToLongFunction<T> idExtractor, Object metadata) {
         boolean hasNext = data.size() > pageSize;
         long nextCursor = -1L;
 
@@ -41,10 +50,10 @@ public class CursorPageResponse<T> {
             data = data.subList(0, pageSize);
         }
 
-        return new CursorPageResponse<>(data, nextCursor, hasNext);
+        return new CursorPageResponse<>(data, nextCursor, hasNext, metadata);
     }
 
     public static <T> CursorPageResponse<T> empty() {
-        return new CursorPageResponse<>(Collections.emptyList(), -1L, false);
+        return new CursorPageResponse<>(Collections.emptyList(), -1L, false, null);
     }
 }

--- a/src/main/java/com/bobeat/backend/global/response/CursorPageResponse.java
+++ b/src/main/java/com/bobeat/backend/global/response/CursorPageResponse.java
@@ -44,8 +44,7 @@ public class CursorPageResponse<T> {
         long nextCursor = -1L;
 
         if (hasNext) {
-            T lastReponse = data.get(pageSize - 1);
-            nextCursor = idExtractor.applyAsLong(lastReponse);
+            nextCursor = idExtractor.applyAsLong(data.getLast());
 
             data = data.subList(0, pageSize);
         }

--- a/src/test/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryImplTest.java
+++ b/src/test/java/com/bobeat/backend/domain/review/repository/ReviewRepositoryImplTest.java
@@ -1,0 +1,149 @@
+package com.bobeat.backend.domain.review.repository;
+
+import com.bobeat.backend.domain.member.entity.Member;
+import com.bobeat.backend.domain.review.entity.Review;
+import com.bobeat.backend.domain.review.entity.ReviewKeyword;
+import com.bobeat.backend.domain.store.entity.Store;
+import com.bobeat.backend.global.request.CursorPaginationRequest;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@Testcontainers
+class ReviewRepositoryImplTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
+    }
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    void 커서_기반_가게별_리뷰_조회_정상_동작() {
+        // given
+        Member member = createAndSaveMember("테스트유저");
+        Store store = createAndSaveStore("테스트 가게");
+
+        Review review1 = createAndSaveReview("첫 번째 리뷰", member, store);
+        Review review2 = createAndSaveReview("두 번째 리뷰", member, store);
+        Review review3 = createAndSaveReview("세 번째 리뷰", member, store);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when - limit 2로 조회 (실제로는 3개 조회하여 hasNext 확인)
+        CursorPaginationRequest request = new CursorPaginationRequest(2, null);
+        List<Review> result = reviewRepository.findByStoreIdWithCursor(store.getId(), request);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getId()).isEqualTo(review3.getId());
+        assertThat(result.get(1).getId()).isEqualTo(review2.getId());
+        assertThat(result.get(2).getId()).isEqualTo(review1.getId());
+    }
+
+    @Test
+    void 커서를_사용한_다음_페이지_조회_정상_동작() {
+        // given
+        Member member = createAndSaveMember("테스트유저");
+        Store store = createAndSaveStore("테스트 가게");
+
+        Review review1 = createAndSaveReview("첫 번째 리뷰", member, store);
+        Review review2 = createAndSaveReview("두 번째 리뷰", member, store);
+        Review review3 = createAndSaveReview("세 번째 리뷰", member, store);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when - 커서를 review2 ID로 설정하여 그 이전 리뷰들 조회
+        CursorPaginationRequest request = new CursorPaginationRequest(2, review2.getId().toString());
+        List<Review> result = reviewRepository.findByStoreIdWithCursor(store.getId(), request);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(review1.getId());
+    }
+
+    @Test
+    void 커서_기반_회원별_리뷰_조회_정상_동작() {
+        // given
+        Member member1 = createAndSaveMember("회원1");
+        Member member2 = createAndSaveMember("회원2");
+        Store store1 = createAndSaveStore("가게1");
+        Store store2 = createAndSaveStore("가게2");
+
+        Review member1Review1 = createAndSaveReview("회원1의 첫 리뷰", member1, store1);
+        Review member1Review2 = createAndSaveReview("회원1의 둘째 리뷰", member1, store2);
+        createAndSaveReview("회원2의 리뷰", member2, store1);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        CursorPaginationRequest request = new CursorPaginationRequest(5, null);
+        List<Review> result = reviewRepository.findByMemberIdWithCursor(member1.getId(), request);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(Review::getId)
+                .containsExactly(member1Review2.getId(), member1Review1.getId());
+    }
+
+   private Member createAndSaveMember(String nickname) {
+        Member member = Member.builder()
+                .nickname(nickname)
+                .build();
+        entityManager.persist(member);
+        return member;
+    }
+
+    private Store createAndSaveStore(String name) {
+        Store store = Store.builder()
+                .name(name)
+                .build();
+        entityManager.persist(store);
+        return store;
+    }
+
+    private Review createAndSaveReview(String content, Member member, Store store) {
+        Review review = Review.builder()
+                .content(content)
+                .keywords(List.of(ReviewKeyword.BEST_TASTE))
+                .member(member)
+                .store(store)
+                .build();
+        entityManager.persist(review);
+        return review;
+    }
+}
+

--- a/src/test/java/com/bobeat/backend/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/bobeat/backend/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,178 @@
+package com.bobeat.backend.domain.review.service;
+
+import com.bobeat.backend.domain.member.entity.Member;
+import com.bobeat.backend.domain.member.repository.MemberRepository;
+import com.bobeat.backend.domain.review.dto.request.CreateReviewRequest;
+import com.bobeat.backend.domain.review.dto.request.UpdateReviewRequest;
+import com.bobeat.backend.domain.review.entity.Review;
+import com.bobeat.backend.domain.review.entity.ReviewKeyword;
+import com.bobeat.backend.domain.review.repository.ReviewRepository;
+import com.bobeat.backend.domain.store.entity.Store;
+import com.bobeat.backend.domain.store.repository.StoreRepository;
+import com.bobeat.backend.global.exception.CustomException;
+import com.bobeat.backend.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+    
+    @Mock
+    private MemberRepository memberRepository;
+    
+    @Mock
+    private StoreRepository storeRepository;
+    
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Test
+    void 이미_리뷰를_작성한_가게에_다시_리뷰_작성시_예외_발생() {
+        // given
+        Long memberId = 1L;
+        Long storeId = 1L;
+        CreateReviewRequest request = createReviewRequest(storeId);
+        
+        Member member = createMember(memberId);
+        Store store = createStore(storeId);
+        
+        given(memberRepository.findByIdOrElseThrow(memberId)).willReturn(member);
+        given(storeRepository.findByIdOrThrow(storeId)).willReturn(store);
+        given(reviewRepository.existsByMemberIdAndStoreId(memberId, storeId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(memberId, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.REVIEW_ALREADY_EXISTS.getMessage());
+    }
+
+    @Test
+    void 다른_사용자의_리뷰_수정시_예외_발생() {
+        // given
+        Long reviewOwnerId = 1L;
+        Long otherMemberId = 2L;
+        Long reviewId = 1L;
+        
+        UpdateReviewRequest request = createUpdateReviewRequest();
+        Review review = createReviewWithMember(reviewId, reviewOwnerId);
+        
+        given(reviewRepository.findByIdOrThrow(reviewId)).willReturn(review);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.updateReview(otherMemberId, reviewId, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.REVIEW_ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    void 다른_사용자의_리뷰_삭제시_예외_발생() {
+        // given
+        Long reviewOwnerId = 1L;
+        Long otherMemberId = 2L;
+        Long reviewId = 1L;
+        
+        Review review = createReviewWithMember(reviewId, reviewOwnerId);
+        
+        given(reviewRepository.findByIdOrThrow(reviewId)).willReturn(review);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.deleteReview(otherMemberId, reviewId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.REVIEW_ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    void 본인_리뷰_수정_성공() {
+        // given
+        Long memberId = 1L;
+        Long reviewId = 1L;
+        
+        UpdateReviewRequest request = createUpdateReviewRequest();
+        Review review = createReviewWithMember(reviewId, memberId);
+        
+        given(reviewRepository.findByIdOrThrow(reviewId)).willReturn(review);
+
+        // when
+        reviewService.updateReview(memberId, reviewId, request);
+
+        // then
+        verify(reviewRepository).findByIdOrThrow(reviewId);
+        assertThat(review.getContent()).isEqualTo("수정된 리뷰 내용");
+        assertThat(review.getKeywords()).containsExactly(ReviewKeyword.KIND_SERVICE);
+    }
+
+    @Test
+    @DisplayName("본인 리뷰 삭제가 성공한다")
+    void 본인_리뷰_삭제_성공() {
+        // given
+        Long memberId = 1L;
+        Long reviewId = 1L;
+        
+        Review review = createReviewWithMember(reviewId, memberId);
+        
+        given(reviewRepository.findByIdOrThrow(reviewId)).willReturn(review);
+
+        // when
+        reviewService.deleteReview(memberId, reviewId);
+
+        // then
+        verify(reviewRepository).delete(review);
+    }
+
+    private CreateReviewRequest createReviewRequest(Long storeId) {
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setStoreId(storeId);
+        request.setContent("맛있어요!");
+        request.setKeywords(List.of(ReviewKeyword.BEST_TASTE, ReviewKeyword.GOOD_FOR_SOLO));
+        return request;
+    }
+
+    private UpdateReviewRequest createUpdateReviewRequest() {
+        UpdateReviewRequest request = new UpdateReviewRequest();
+        request.setContent("수정된 리뷰 내용");
+        request.setKeywords(List.of(ReviewKeyword.KIND_SERVICE));
+        return request;
+    }
+
+    private Member createMember(Long memberId) {
+        return Member.builder()
+                .id(memberId)
+                .nickname("테스트유저")
+                .build();
+    }
+
+    private Store createStore(Long storeId) {
+        return Store.builder()
+                .id(storeId)
+                .name("테스트 가게")
+                .build();
+    }
+
+    private Review createReviewWithMember(Long reviewId, Long memberId) {
+        Member member = createMember(memberId);
+        Store store = createStore(1L);
+        
+        return Review.builder()
+                .id(reviewId)
+                .content("기존 리뷰 내용")
+                .keywords(List.of(ReviewKeyword.BEST_TASTE))
+                .member(member)
+                .store(store)
+                .build();
+    }
+}


### PR DESCRIPTION
### 🔖 Title

###   1. Summary 📝

  - 리뷰 생성, 조회, 수정, 삭제 API구현
  - 가게별/회원별 리뷰 조회에 커서 기반 페이지네이션을 적용
  - 배열을 사용해 리뷰 키워드를 효율적으로 저장

###   2. Domain
  - [x] Review

### 3. Type
  - [x] Feature ✨

### 4. Changes(detail)

  1. Controller REST API 구현
    - POST /api/reviews (리뷰
  생성)
    - GET
  /api/stores/{storeId}/reviews
  (가게별 리뷰 조회)
    - GET /api/members/{memberId
  }/reviews (회원별 리뷰 조회)
    - PUT
  /api/reviews/{reviewId} (리뷰
  수정)
    - DELETE
  /api/reviews/{reviewId} (리뷰
  삭제)

2.  CursorPageResponse lastID 반환 수정
 Before: N번째 id 반환
 After: N+1번째 id 반환
 
그리고 metadata도 담을 수 있게 속성 추가했습니다

