### PR TITLE
[Common][Feat] 디스코드 에러 알림 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Gradle 를 준비한다.
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
+      - name: 테스트 애플리케이션yml을 생성한다
+        run: |
+          mkdir -p src/test/resources
+          echo "${{ secrets.APPLICATION_TEST_YML }}" | base64 -d > src/test/resources/application.yml
+
       - name: 빌드한다.
         run: ./gradlew build --stacktrace
 

--- a/src/main/java/com/bobeat/backend/global/config/DiscordWebhookConfig.java
+++ b/src/main/java/com/bobeat/backend/global/config/DiscordWebhookConfig.java
@@ -1,0 +1,21 @@
+package com.bobeat.backend.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Discord 웹훅 관련 설정을 관리하는 Configuration
+ */
+@Configuration
+@Getter
+public class DiscordWebhookConfig {
+
+    @Value("${discord.webhook.url:}")
+    private String webhookUrl;
+
+
+    public boolean isWebhookConfigured() {
+        return webhookUrl != null && !webhookUrl.trim().isEmpty();
+    }
+} 

--- a/src/main/java/com/bobeat/backend/global/config/ErrorNotificationConfig.java
+++ b/src/main/java/com/bobeat/backend/global/config/ErrorNotificationConfig.java
@@ -1,0 +1,39 @@
+package com.bobeat.backend.global.config;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 에러 알림 설정을 관리하는 Configuration
+ */
+@Configuration
+@ConfigurationProperties(prefix = "error.notification")
+@Getter
+@Setter
+public class ErrorNotificationConfig {
+
+    private boolean enabled = true;
+    private boolean includeClientErrors = true;
+    private List<String> excludedPaths;
+    private int maxStackTraceLines = 10;
+
+    /**
+     * 특정 경로가 알림에서 제외되는지 확인합니다.
+     */
+    public boolean isPathExcluded(String path) {
+        if (excludedPaths == null) {
+            return false;
+        }
+        return excludedPaths.stream().anyMatch(path::startsWith);
+    }
+
+    /**
+     * 디스코드 알림 활성화 여부를 확인합니다.
+     */
+    public boolean isDiscordNotificationEnabled() {
+        return enabled;
+    }
+} 

--- a/src/main/java/com/bobeat/backend/global/error_notification/DiscordErrorNotificationDto.java
+++ b/src/main/java/com/bobeat/backend/global/error_notification/DiscordErrorNotificationDto.java
@@ -1,0 +1,197 @@
+package com.bobeat.backend.global.error_notification;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DiscordErrorNotificationDto {
+    private final String title;
+    private final String description;
+    private final int color;
+    private final String timestamp;
+    private final List<Map<String, Object>> fields;
+
+    public DiscordErrorNotificationDto(ErrorNotificationDto dto) {
+        this.title = determineTitle(dto);
+        this.color = determineColor(dto);
+        this.description = buildDescription(dto);
+        this.timestamp = getIsoTimestamp();
+
+        List<Map<String, Object>> fields = new ArrayList<>();
+        fields.addAll(splitIntoFields("Request Headers", dto.getRequestHeaders()));
+        fields.addAll(splitIntoFields("Request Parameters", dto.getRequestParams()));
+        fields.addAll(splitIntoFields("Request Body", dto.getRequestBody()));
+        
+        // 예외 체인을 구분해서 표시
+        addExceptionChainFields(fields, dto);
+        
+        this.fields = fields;
+    }
+
+    /**
+     * 에러 타입에 따른 제목 결정
+     */
+    private String determineTitle(ErrorNotificationDto dto) {
+        if (dto.getErrorCode().startsWith("4")) {
+            return "⚠️ 클라이언트 에러 발생";
+        } else if (dto.getErrorCode().startsWith("5")) {
+            return "🚨 서버 에러 발생";
+        } else {
+            return "❗ 에러 발생";
+        }
+    }
+
+    /**
+     * 에러 타입에 따른 색상 결정
+     */
+    private int determineColor(ErrorNotificationDto dto) {
+        if (dto.getErrorCode().startsWith("4")) {
+            return 16776960; // 노란색 (클라이언트 에러)
+        } else if (dto.getErrorCode().startsWith("5")) {
+            return 16711680; // 빨간색 (서버 에러)
+        } else {
+            return 8421504; // 회색 (기타)
+        }
+    }
+
+    /**
+     * 예외 체인을 구분해서 필드에 추가
+     */
+    private void addExceptionChainFields(List<Map<String, Object>> fields, ErrorNotificationDto dto) {
+        if (dto.getExceptionChain() == null || dto.getExceptionChain().isEmpty()) {
+            // 기존 방식으로 폴백
+            fields.add(Map.of(
+                    "name", "스택 트레이스",
+                    "value", "```" + truncate(dto.getStackTrace(), 1000) + "```",
+                    "inline", false
+            ));
+            return;
+        }
+
+        for (ErrorNotificationDto.ExceptionChainDto exception : dto.getExceptionChain()) {
+            String fieldName = getExceptionFieldName(exception);
+            String exceptionInfo = buildExceptionInfo(exception);
+            
+            fields.add(Map.of(
+                    "name", fieldName,
+                    "value", "```" + exceptionInfo + "```",
+                    "inline", false
+            ));
+        }
+    }
+
+    /**
+     * 예외 순서에 따른 필드 이름 생성
+     */
+    private String getExceptionFieldName(ErrorNotificationDto.ExceptionChainDto exception) {
+        if (exception.getOrder() == 0) {
+            return "- 예외: " + exception.getExceptionType();
+        } else {
+            return "- 상위 원인: " + exception.getExceptionType();
+        }
+    }
+
+    /**
+     * 예외 정보를 문자열로 구성 (메시지 + 스택 트레이스)
+     */
+    private String buildExceptionInfo(ErrorNotificationDto.ExceptionChainDto exception) {
+        StringBuilder sb = new StringBuilder();
+
+        // 예외 메시지 추가
+        if (exception.getMessage() != null && !exception.getMessage().isEmpty()) {
+            sb.append("메시지: ").append(exception.getMessage()).append("\n\n");
+        }
+
+        // 스택 트레이스 추가
+        if (exception.getStackTrace() != null && !exception.getStackTrace().isEmpty()) {
+            sb.append("스택 트레이스:\n").append(exception.getStackTrace());
+        }
+
+        // 아무것도 없으면 예외 타입만 반환
+        if (sb.length() == 0) {
+            return exception.getExceptionType();
+        }
+
+        return truncate(sb.toString(), 900);
+    }
+
+    public Map<String, Object> toEmbed() {
+        Map<String, Object> embed = new HashMap<>();
+        embed.put("title", title);
+        embed.put("description", description);
+        embed.put("color", color);
+        embed.put("timestamp", timestamp);
+        embed.put("fields", fields);
+        return embed;
+    }
+
+    private static String buildDescription(ErrorNotificationDto dto) {
+        return String.format(
+                "**에러 코드**: %s\n" +
+                        "**에러 메시지**: %s\n" +
+                        "**예외 타입**: %s\n" +
+                        "**예외 메시지**: %s\n" +
+                        "**요청 URI**: %s\n" +
+                        "**요청 메소드**: %s\n" +
+                        "**클라이언트 IP**: %s\n" +
+                        "**User-Agent**: %s",
+                safe(dto.getErrorCode()),
+                safe(dto.getErrorMessage()),
+                safe(dto.getExceptionType()),
+                truncate(dto.getExceptionMessage(), 100),
+                safe(dto.getRequestUri()),
+                safe(dto.getRequestMethod()),
+                safe(dto.getClientIp()),
+                truncate(dto.getUserAgent(), 100)
+        );
+    }
+
+    private static String getIsoTimestamp() {
+        return ZonedDateTime.now(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT);
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String truncate(String str, int max) {
+        if (str == null) {
+            return "";
+        }
+        if (str.length() <= max) {
+            return str;
+        }
+        return str.substring(0, max) + "...";
+    }
+
+    private static List<Map<String, Object>> splitIntoFields(String name, String value) {
+        List<Map<String, Object>> fields = new ArrayList<>();
+        if (value == null || value.isEmpty()) {
+            fields.add(Map.of(
+                    "name", name,
+                    "value", "``` ```",
+                    "inline", false
+            ));
+            return fields;
+        }
+
+        int maxChunkSize = 900; // 디스코드 1024자 제한에 여유 두기
+        int valueLength = value.length();
+        int partNumber = 1;
+        for (int i = 0; i < valueLength; i += maxChunkSize) {
+            String chunk = value.substring(i, Math.min(valueLength, i + maxChunkSize));
+            String fieldName = valueLength > maxChunkSize ? String.format("%s (%d)", name, partNumber++) : name;
+            fields.add(Map.of(
+                    "name", fieldName,
+                    "value", "```" + chunk + "```",
+                    "inline", false
+            ));
+        }
+        return fields;
+    }
+
+} 

--- a/src/main/java/com/bobeat/backend/global/error_notification/ErrorNotificationDto.java
+++ b/src/main/java/com/bobeat/backend/global/error_notification/ErrorNotificationDto.java
@@ -1,0 +1,198 @@
+package com.bobeat.backend.global.error_notification;
+
+import com.bobeat.backend.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+/**
+ * 에러 알림에 필요한 데이터를 담는 DTO
+ */
+@Data
+@Builder
+public class ErrorNotificationDto {
+
+    private String timestamp;
+    private String errorCode;
+    private String errorMessage;
+    private String exceptionType;
+    private String exceptionMessage;
+    private String requestUri;
+    private String requestMethod;
+    private String userAgent;
+    private String clientIp;
+    private String requestParams;
+    private String requestBody;
+    private String requestHeaders;
+    private String stackTrace;
+    private List<ExceptionChainDto> exceptionChain; // 예외 체인 정보 추가
+
+    @Data
+    @Builder
+    public static class ExceptionChainDto {
+        private String exceptionType;
+        private String message;
+        private String stackTrace;
+        private int order; // 예외 발생 순서 (0: 최상위, 1: 첫 번째 원인, ...)
+    }
+
+    public static ErrorNotificationDto create(ErrorCode errorCode, Exception exception,
+                                              HttpServletRequest request) {
+
+        String requestBody = "";
+        if (request instanceof ContentCachingRequestWrapper) {
+            requestBody = getRequestBody((ContentCachingRequestWrapper) request);
+        }
+
+        return ErrorNotificationDto.builder()
+                .timestamp(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .errorCode(errorCode.getCode())
+                .errorMessage(errorCode.getMessage())
+                .exceptionType(exception.getClass().getSimpleName())
+                .exceptionMessage(exception.getMessage())
+                .requestUri(request.getRequestURI())
+                .requestMethod(request.getMethod())
+                .userAgent(request.getHeader("User-Agent"))
+                .clientIp(getClientIp(request))
+                .requestParams(getRequestParams(request))
+                .requestBody(requestBody)
+                .requestHeaders(getRequestHeaders(request))
+                .stackTrace(getStackTraceAsString(exception))
+                .exceptionChain(buildExceptionChain(exception)) // 예외 체인 구축
+                .build();
+    }
+
+    /**
+     * 예외 체인을 분석하여 상위 예외부터 하위 원인 예외까지 순서대로 구성
+     */
+    private static List<ExceptionChainDto> buildExceptionChain(Exception exception) {
+        List<ExceptionChainDto> chain = new ArrayList<>();
+        Throwable current = exception;
+        int order = 0;
+
+        while (current != null) {
+            chain.add(ExceptionChainDto.builder()
+                    .exceptionType(current.getClass().getSimpleName())
+                    .message(current.getMessage())
+                    .stackTrace(getStackTraceForException(current, 5)) // 각 예외당 5줄로 제한
+                    .order(order++)
+                    .build());
+
+            current = current.getCause();
+        }
+
+        return chain;
+    }
+
+    /**
+     * 특정 예외의 스택 트레이스를 제한된 줄 수와 문자 수로 반환
+     */
+    private static String getStackTraceForException(Throwable exception, int maxLines) {
+        StringBuilder sb = new StringBuilder();
+        StackTraceElement[] stackTrace = exception.getStackTrace();
+        
+        int maxChars = 800; // 메시지와 합쳐도 1024자를 넘지 않도록 여유있게 설정
+        int linesToInclude = Math.min(stackTrace.length, maxLines);
+        
+        for (int i = 0; i < linesToInclude; i++) {
+            String line = stackTrace[i].toString() + "\n";
+            
+            // 추가했을 때 최대 문자 수를 넘으면 중단
+            if (sb.length() + line.length() > maxChars) {
+                sb.append("... (길이 제한으로 생략)");
+                break;
+            }
+            
+            sb.append(line);
+        }
+
+        // 라인 수 제한으로 생략된 경우에만 표시 (문자 수 제한으로 생략된 경우 위에서 이미 표시)
+        if (stackTrace.length > maxLines && sb.length() <= maxChars) {
+            sb.append("... (총 ").append(stackTrace.length).append("줄)");
+        }
+
+        return sb.toString();
+    }
+
+    private static String getRequestHeaders(HttpServletRequest request) {
+        Map<String, String> headers = new HashMap<>();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            headers.put(headerName, request.getHeader(headerName));
+        }
+
+        if (headers.isEmpty()) {
+            return "No Headers";
+        }
+        return headers.toString();
+    }
+
+    private static String getRequestParams(HttpServletRequest request) {
+        Map<String, String> params = new HashMap<>();
+        Enumeration<String> paramNames = request.getParameterNames();
+        while (paramNames.hasMoreElements()) {
+            String paramName = paramNames.nextElement();
+            params.put(paramName, request.getParameter(paramName));
+        }
+
+        if (params.isEmpty()) {
+            return "No Parameters";
+        }
+        return params.toString();
+    }
+
+    private static String getRequestBody(ContentCachingRequestWrapper request) {
+        byte[] content = request.getContentAsByteArray();
+        if (content.length == 0) {
+            return "No Body";
+        }
+        return new String(content, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 스택 트레이스를 문자열로 변환합니다.
+     */
+    private static String getStackTraceAsString(Exception exception) {
+        StringBuilder sb = new StringBuilder();
+        StackTraceElement[] stackTrace = exception.getStackTrace();
+
+        // 설정된 최대 라인 수까지만 포함
+        int linesToInclude = Math.min(stackTrace.length, 10);
+        for (int i = 0; i < linesToInclude; i++) {
+            sb.append(stackTrace[i].toString()).append("\n");
+        }
+
+        if (stackTrace.length > 10) {
+            sb.append("... (총 ").append(stackTrace.length).append("줄)");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * 클라이언트 IP 주소를 가져옵니다.
+     */
+    private static String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (xRealIp != null && !xRealIp.isEmpty()) {
+            return xRealIp;
+        }
+
+        return request.getRemoteAddr();
+    }
+} 

--- a/src/main/java/com/bobeat/backend/global/error_notification/ErrorNotificationService.java
+++ b/src/main/java/com/bobeat/backend/global/error_notification/ErrorNotificationService.java
@@ -1,0 +1,19 @@
+package com.bobeat.backend.global.error_notification;
+
+import com.bobeat.backend.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 에러 알림 서비스 인터페이스 다양한 알림 채널(디스코드, 슬랙 등)을 지원할 수 있도록 확장 가능한 구조
+ */
+public interface ErrorNotificationService {
+
+    /**
+     * 에러 알림을 전송합니다.
+     *
+     * @param errorCode 에러 코드
+     * @param exception 발생한 예외
+     * @param request   HTTP 요청 정보
+     */
+    void sendErrorNotification(ErrorCode errorCode, Exception exception, HttpServletRequest request);
+} 

--- a/src/main/java/com/bobeat/backend/global/error_notification/SenderToDiscord.java
+++ b/src/main/java/com/bobeat/backend/global/error_notification/SenderToDiscord.java
@@ -1,0 +1,171 @@
+package com.bobeat.backend.global.error_notification;
+
+import com.bobeat.backend.global.config.DiscordWebhookConfig;
+import com.bobeat.backend.global.config.ErrorNotificationConfig;
+import com.bobeat.backend.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * 디스코드 웹훅을 통한 에러 알림 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SenderToDiscord implements ErrorNotificationService {
+
+    private final DiscordWebhookConfig discordWebhookConfig;
+    private final ErrorNotificationConfig errorNotificationConfig;
+    private final WebClient webClient;
+
+    @Override
+    public void sendErrorNotification(ErrorCode errorCode, Exception exception, HttpServletRequest request) {
+        if (!shouldSendNotification(errorCode, request)) {
+            return;
+        }
+
+        try {
+            ErrorNotificationDto notificationDto = ErrorNotificationDto.create(errorCode, exception, request);
+            sendDiscordNotification(notificationDto);
+        } catch (Exception e) {
+            log.error("디스코드 에러 알림 전송 실패", e);
+        }
+    }
+
+    /**
+     * 알림 전송 여부를 판단합니다.
+     */
+    private boolean shouldSendNotification(ErrorCode errorCode, HttpServletRequest request) {
+        if (!errorNotificationConfig.isDiscordNotificationEnabled()) {
+            log.debug("에러 알림이 비활성화되어 있습니다.");
+            return false;
+        }
+
+        if (!discordWebhookConfig.isWebhookConfigured()) {
+            log.debug("디스코드 웹훅이 설정되지 않았습니다.");
+            return false;
+        }
+
+        if (errorNotificationConfig.isPathExcluded(request.getRequestURI())) {
+            log.debug("제외된 경로입니다: {}", request.getRequestURI());
+            return false;
+        }
+
+        if (!errorNotificationConfig.isIncludeClientErrors() &&
+            errorCode.getHttpStatus().is4xxClientError()) {
+            log.debug("클라이언트 에러는 알림에서 제외됩니다: {}", errorCode.getCode());
+            return false;
+        }
+
+        return true;
+    }
+
+    private void sendDiscordNotification(ErrorNotificationDto notificationDto) {
+        try {
+            DiscordErrorNotificationDto discordDto = new DiscordErrorNotificationDto(notificationDto);
+            Map<String, Object> payload = Map.of("embeds", List.of(discordDto.toEmbed()));
+
+            String payloadJson = payload.toString();
+            log.debug("디스코드 페이로드 크기: {} 문자", payloadJson.length());
+
+            webClient.post()
+                    .uri(discordWebhookConfig.getWebhookUrl())
+                    .bodyValue(payload)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .doOnSuccess(response -> log.info("디스코드 에러 알림 전송 완료: {}", notificationDto.getErrorCode()))
+                    .doOnError(this::logDiscordError)
+                    .subscribe();
+        } catch (Exception e) {
+            log.error("디스코드 알림 생성 중 에러 발생", e);
+        }
+    }
+
+    /**
+     * 디스코드 전송 에러를 로깅합니다.
+     */
+    private void logDiscordError(Throwable error) {
+        log.error("디스코드 웹훅 전송 실패: {}", error.getMessage());
+
+        if (error instanceof WebClientResponseException webClientError) {
+            log.error("디스코드 응답 상태: {}, 응답 본문: {}",
+                    webClientError.getStatusCode(),
+                    webClientError.getResponseBodyAsString());
+        }
+    }
+
+    /**
+     * 간단한 로그 메시지를 디스코드로 전송
+     */
+    public void sendLog(String title, String message) {
+        sendLog(title, message, 3447003); // 기본 파란색
+    }
+
+    /**
+     * 색상을 지정하여 로그 메시지를 디스코드로 전송
+     */
+    public void sendLog(String title, String message, int color) {
+        if (!discordWebhookConfig.isWebhookConfigured()) {
+            log.debug("디스코드 웹훅이 설정되지 않았습니다.");
+            return;
+        }
+
+        try {
+            Map<String, Object> embed = createSimpleEmbed(title, message, color);
+            Map<String, Object> payload = Map.of("embeds", List.of(embed));
+
+            webClient.post()
+                    .uri(discordWebhookConfig.getWebhookUrl())
+                    .bodyValue(payload)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .doOnSuccess(response -> log.info("디스코드 로그 전송 완료: {}", title))
+                    .doOnError(this::logDiscordError)
+                    .subscribe();
+        } catch (Exception e) {
+            log.error("디스코드 로그 전송 실패", e);
+        }
+    }
+
+    /**
+     * 간단한 embed 객체 생성
+     */
+    private Map<String, Object> createSimpleEmbed(String title, String message, int color) {
+        Map<String, Object> embed = new HashMap<>();
+        embed.put("title", title);
+        embed.put("description", truncateMessage(message, 1000)); // 디스코드 description 제한
+        embed.put("color", color);
+        embed.put("timestamp", getIsoTimestamp());
+        return embed;
+    }
+
+    /**
+     * 메시지 길이 제한
+     */
+    private String truncateMessage(String message, int maxLength) {
+        if (message == null) {
+            return "";
+        }
+        if (message.length() <= maxLength) {
+            return message;
+        }
+        return message.substring(0, maxLength - 3) + "...";
+    }
+
+    /**
+     * ISO 타임스탬프 생성
+     */
+    private String getIsoTimestamp() {
+        return ZonedDateTime.now(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT);
+    }
+}

--- a/src/main/java/com/bobeat/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bobeat/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.bobeat.backend.global.exception;
 
+import com.bobeat.backend.global.error_notification.ErrorNotificationService;
 import com.bobeat.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -11,39 +14,52 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @Slf4j
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private final ErrorNotificationService errorNotificationService;
+
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ApiResponse<Object>> handleException(RuntimeException e) {
+    public ResponseEntity<ApiResponse<Object>> handleException(RuntimeException e, HttpServletRequest request) {
+        log.error("[서버 에러] from {} api", request.getRequestURI(), e);
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER);
+        sendErrorNotification(ErrorCode.INTERNAL_SERVER, e, request);
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER.getHttpStatus())
                 .body(handleException(e, errorResponse));
     }
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e) {
+    public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e, HttpServletRequest request) {
+        log.error("[커스텀 에러] {} from {} api", e.getErrorCode().getCode(), request.getRequestURI(), e);
         ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
+        sendErrorNotification(e.getErrorCode(), e, request);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(handleException(e, errorResponse));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Object>> handleValidateException(MethodArgumentNotValidException e){
+    public ResponseEntity<ApiResponse<Object>> handleValidateException(MethodArgumentNotValidException e, HttpServletRequest request){
+        log.error("[검증 에러] from {} api", request.getRequestURI(), e);
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.BAD_REQUEST);
+        sendErrorNotification(ErrorCode.BAD_REQUEST, e, request);
         return ResponseEntity.status(ErrorCode.BAD_REQUEST.getHttpStatus())
                 .body(handleException(e, errorResponse));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ApiResponse<Object>> handleAccessDeniedException(AccessDeniedException e) {
+    public ResponseEntity<ApiResponse<Object>> handleAccessDeniedException(AccessDeniedException e, HttpServletRequest request) {
+        log.error("[접근 거부] from {} api", request.getRequestURI(), e);
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.FORBIDDEN);
+        sendErrorNotification(ErrorCode.FORBIDDEN, e, request);
         return ResponseEntity.status(ErrorCode.FORBIDDEN.getHttpStatus())
                 .body(handleException(e, errorResponse));
     }
 
     @ExceptionHandler(InsufficientAuthenticationException.class)
-    public ResponseEntity<ApiResponse<Object>> handleInsufficientAuthenticationException(InsufficientAuthenticationException e) {
+    public ResponseEntity<ApiResponse<Object>> handleInsufficientAuthenticationException(InsufficientAuthenticationException e, HttpServletRequest request) {
+        log.error("[인증 부족] from {} api", request.getRequestURI(), e);
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.UNAUTHORIZED);
+        sendErrorNotification(ErrorCode.UNAUTHORIZED, e, request);
         return ResponseEntity.status(ErrorCode.UNAUTHORIZED.getHttpStatus())
                 .body(handleException(e, errorResponse));
     }
@@ -51,5 +67,16 @@ public class GlobalExceptionHandler {
     public ApiResponse<Object> handleException(Exception e, ErrorResponse errorResponse) {
         log.error("{}: {}", errorResponse.code(), e.getMessage());
         return ApiResponse.error(errorResponse);
+    }
+
+    /**
+     * 에러 알림을 전송합니다.
+     */
+    private void sendErrorNotification(ErrorCode errorCode, Exception exception, HttpServletRequest request) {
+        try {
+            errorNotificationService.sendErrorNotification(errorCode, exception, request);
+        } catch (Exception e) {
+            log.error("에러 알림 전송 중 예외 발생", e);
+        }
     }
 }

--- a/src/test/java/com/bobeat/backend/domain/store/repository/StoreRepositoryImplTest.java
+++ b/src/test/java/com/bobeat/backend/domain/store/repository/StoreRepositoryImplTest.java
@@ -93,9 +93,9 @@ public class StoreRepositoryImplTest {
 
         // 좌석 옵션 (A: FOR_ONE, B: BAR_TABLE)
         seatOptionRepository.save(SeatOption.builder()
-                .store(storeA).seatType(SeatType.FOR_ONE).maxCapacity(1).build());
+                .store(storeA).seatType(SeatType.FOR_ONE).build());
         seatOptionRepository.save(SeatOption.builder()
-                .store(storeB).seatType(SeatType.BAR_TABLE).maxCapacity(4).build());
+                .store(storeB).seatType(SeatType.BAR_TABLE).build());
     }
 
     @Test


### PR DESCRIPTION

### 1. Summary 📝
- 디스코드 에러 알림 구현

### 2. Related Issue 🔗
- Close #38 

### 3. Domain
- [ ] User 👤
- [ ] Admin 🛠️
- [ ] Food 🍔
- [x] Common

### 4. Type
- [x] Feature ✨
- [ ] Bug Fix 🐛
- [ ] Refactor ♻️
- [ ] Docs 📚


### 5. Changes(detail)
Discord Error Notification 시스템 각 클래스 
  역할

  **1. ErrorNotificationConfig.java**
  역할: 에러 알림 시스템의 전반적인 설정을
  관리하는 Configuration 클래스
  - 알림 활성화/비활성화 (enabled)
  - 클라이언트 에러 포함 여부
  (includeClientErrors)
  - 제외할 경로 목록 (excludedPaths)
  - 스택 트레이스 최대 라인 수
  (maxStackTraceLines)
  - 경로별 알림 제외 로직 제공

  **2. DiscordWebhookConfig.java**
  역할: Discord 웹훅 관련 설정을 관리하는
  Configuration 클래스
  - Discord 웹훅 URL 설정 (webhookUrl)
  - 웹훅 설정 상태 확인 기능
  (isWebhookConfigured())
  - Discord 알림 전송을 위한 기본 설정 제공

  **3. ErrorNotificationService.java**
  역할: 에러 알림 서비스의 인터페이스
  - 다양한 알림 채널(Discord, Slack 등)을
  지원할 수 있는 확장 가능한 구조
  - sendErrorNotification() 메서드로 에러 알림
  전송 계약 정의
  - 향후 다른 알림 서비스 구현체 추가 시 활용

  **4. ErrorNotificationDto.java**
  역할: 에러 알림에 필요한 모든 데이터를
  수집하고 구조화하는 DTO
  - HTTP 요청 정보 추출 (헤더, 파라미터, 바디,
  IP 등)
  - 예외 정보 수집 및 가공 (타입, 메시지, 스택
  트레이스)
  - 예외 체인 분석 및 구조화
  (ExceptionChainDto)
  - 알림 채널에 독립적인 표준 데이터 형식 제공

  **5. DiscordErrorNotificationDto.java**
  역할: ErrorNotificationDto를 Discord Embed
  형식으로 변환하는 DTO
  - Discord API 규격에 맞는 Embed 객체 생성
  - 에러 타입별 동적 제목/색상 결정
  (4xx=노란색, 5xx=빨간색)
  - 예외 체인을 Discord 필드로 변환
  - Discord 문자 수 제한에 맞는 데이터 
  truncation 처리

  **6. SenderToDiscord.java**
  역할: Discord 웹훅을 통한 실제 알림 전송을
  담당하는 Service
  - ErrorNotificationService 인터페이스 구현체
  - 알림 전송 조건 판단
  (shouldSendNotification())
  - Discord 웹훅 API 호출 및 에러 처리
  - 간단한 로그 메시지 전송 기능 (sendLog())
  - WebClient를 통한 비동기 HTTP 통신

  **7. GlobalExceptionHandler.java**
  역할: 전역 예외 처리 및 알림 트리거 역할
  - ErrorNotificationService를 통한 Discord 
  알림 트리거
  - 예외 발생 시 완전한 스택 트레이스 로깅 + 
  Discord 요약 알림 이중화


### 6. 리뷰어가 알아야 할 사항
노션에 yml 업데이트 해놨습니다
