### PR TITLE
[CI/CD][Fix] prod, test 환경 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: 빌드한다.
         run: ./gradlew build --stacktrace
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
       # Test 후 Report 생성
       - name: 테스트 결과를 게시한다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 테스트 애플리케이션yml을 생성한다
         run: |
           mkdir -p src/test/resources
-          echo "${{ secrets.APPLICATION_TEST_YML }}" | base64 -d > src/test/resources/application.yml
+          echo "${{ secrets.APPLICATION_TEST_YML }}" | base64 -d > src/main/resources/application.yml
 
       - name: 빌드한다.
         run: ./gradlew build --stacktrace

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - bobeat-network
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - /var/log/bobeat:/app/logs
+      - /root/logs:/app/logs
 networks:
   bobeat-network:
     driver: bridge

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     container_name: bobeat
     image: ji0513ji/bobeat
     restart: on-failure
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
     ports:
       - "8080:8080"
     networks:

--- a/src/main/java/com/bobeat/backend/domain/store/dto/response/MenuDto.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/response/MenuDto.java
@@ -12,13 +12,17 @@ public record MenuDto(
         @Schema(description = "메뉴 가격")
         int price,
         @Schema(description = "대표 메뉴 여부")
-        boolean isRepresentative
+        boolean isRepresentative,
+        @Schema(description = "메뉴 이미지 URL")
+        String imageUrl
+
 ) {
     public static MenuDto from(Menu menu) {
         return MenuDto.builder()
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .isRepresentative(menu.isRecommend())
+                .imageUrl(menu.getImageUrl())
                 .build();
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,27 +9,35 @@
 
     <!-- 일별 파일 출력 -->
     <appender name="DAILY_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/app/logs/bobeat-${BY_DATE}.log</file>
+        <file>logs/bobeat.log</file>
         <encoder>
             <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} %5level %logger{36} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/app/logs/%d{yyyy-MM}/bobeat-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>logs/%d{yyyy-MM}/bobeat-%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
             <totalSizeCap>10GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 
-    <!-- 루트 로거 설정 -->
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="DAILY_FILE"/>
-    </root>
+    <!-- 테스트 환경: 콘솔만 사용 -->
+    <springProfile name="test">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="com.bobeat.backend" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>
+    </springProfile>
 
-    <!-- 애플리케이션 로그 레벨 설정 -->
-    <logger name="com.bobeat.backend" level="INFO"/>
-
-    <!-- 하이버네이트 SQL 로그 (필요시) -->
-    <logger name="org.hibernate.SQL" level="DEBUG"/>
-    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>
+    <!-- 개발/운영 환경: 콘솔 + 파일 -->
+    <springProfile name="!test">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="DAILY_FILE"/>
+        </root>
+        <logger name="com.bobeat.backend" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>
+    </springProfile>
 </configuration>

--- a/src/test/java/com/bobeat/backend/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/bobeat/backend/domain/store/service/StoreServiceTest.java
@@ -81,6 +81,7 @@ public class StoreServiceTest {
                         .price(9000)
                         .recommend(true)
                         .store(store)
+                        .imageUrl("김치찌개.jpg")
                         .build(),
                 Menu.builder()
                         .id(2L)
@@ -88,6 +89,7 @@ public class StoreServiceTest {
                         .price(9000)
                         .recommend(false)
                         .store(store)
+                        .imageUrl("된장찌개.jpg")
                         .build()
         );
 
@@ -110,5 +112,8 @@ public class StoreServiceTest {
         Assertions.assertThat(response.thumbnailUrls().size()).isEqualTo(2);
         Assertions.assertThat(response.menus().size()).isEqualTo(2);
         Assertions.assertThat(response.seatImages().size()).isEqualTo(2);
+        Assertions.assertThat(response.menus())
+                .extracting("imageUrl")
+                .containsExactlyInAnyOrder("김치찌개.jpg", "된장찌개.jpg");
     }
 }


### PR DESCRIPTION
- 로그 경로 위치 /var/logs -> root/logs (root로 접속해 바로 폴더를 확인할 수 있으므로)
- CI환경에서 로그백을 주입 받는 과정에서 스프링이 쓰려고 하지만 깃허브 액션은 쓰기 권한이 없어 실패 
  - 그래서 로그백이 테스트에서 실행이 안되도록 prod, test. 분리 