### PR TITLE
[Food][Fix] 리뷰 조회 시 레벨까지 받아올 수 있도록 수정

### DIFF
--- a/src/main/java/com/bobeat/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/bobeat/backend/domain/member/entity/Member.java
@@ -1,24 +1,13 @@
 package com.bobeat.backend.domain.member.entity;
 
 import com.bobeat.backend.domain.common.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "member")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/bobeat/backend/domain/member/entity/MemberOnboardingProfile.java
+++ b/src/main/java/com/bobeat/backend/domain/member/entity/MemberOnboardingProfile.java
@@ -5,14 +5,14 @@ import com.bobeat.backend.domain.member.dto.request.OnboardingRequest;
 import com.bobeat.backend.global.exception.CustomException;
 import com.bobeat.backend.global.exception.ErrorCode;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "member_onboarding_profile")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class MemberOnboardingProfile extends BaseTimeEntity {
 
     @Id
@@ -35,7 +35,7 @@ public class MemberOnboardingProfile extends BaseTimeEntity {
     private OnboardingAnswer question5;
 
     @Enumerated(EnumType.STRING)
-    private Level honbapLevel = Level.LEVEL_1;
+    private Level honbobLevel = Level.LEVEL_1;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -67,10 +67,10 @@ public class MemberOnboardingProfile extends BaseTimeEntity {
         }
     }
 
-    public Level calculateAndUpdateHonbapLevel() {
+    public Level calculateAndUpdateHonbobLevel() {
         double totalWeightedScore = calculateTotalWeightedScore();
         Level level = OnboardingAnswer.calculateLevel(totalWeightedScore);
-        this.honbapLevel = level;
+        this.honbobLevel = level;
         return level;
     }
 

--- a/src/main/java/com/bobeat/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/bobeat/backend/domain/member/service/MemberService.java
@@ -20,16 +20,16 @@ public class MemberService {
     public MemberProfileResponse getMyProfile(Long memberId) {
         Member member = memberRepository.findByIdWithOnboardingProfileOrElseThrow(memberId);
 
-        int honbapLevelValue = -1;
+        int honbobLevelValue = -1;
         if (member.getOnboardingProfile() != null) {
-            honbapLevelValue = member.getOnboardingProfile().getHonbapLevel().getValue();
+            honbobLevelValue = member.getOnboardingProfile().getHonbobLevel().getValue();
         }
 
         return new MemberProfileResponse(
                 member.getId().toString(),
                 member.getNickname(),
                 member.getProfileImageUrl(),
-                honbapLevelValue
+                honbobLevelValue
         );
     }
 

--- a/src/main/java/com/bobeat/backend/domain/member/service/OnboardingService.java
+++ b/src/main/java/com/bobeat/backend/domain/member/service/OnboardingService.java
@@ -30,7 +30,7 @@ public class OnboardingService {
 
         MemberOnboardingProfile profile = createOrUpdateOnboardingProfile(member, request);
 
-        Level level = profile.calculateAndUpdateHonbapLevel();
+        Level level = profile.calculateAndUpdateHonbobLevel();
 
         onboardingProfileRepository.save(profile);
 

--- a/src/main/java/com/bobeat/backend/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/bobeat/backend/domain/review/dto/response/ReviewResponse.java
@@ -43,6 +43,9 @@ public class ReviewResponse {
         
         @Schema(description = "프로필 이미지 URL")
         private String profileImageUrl;
+
+        @Schema(description = "사용자의 혼밥레벨", example = "3")
+        private int honbobLevel;
     }
     
     public static ReviewResponse from(com.bobeat.backend.domain.review.entity.Review review) {
@@ -52,7 +55,8 @@ public class ReviewResponse {
                 new ReviewerInfo(
                         review.getMember().getId(),
                         review.getMember().getNickname(),
-                        review.getMember().getProfileImageUrl()
+                        review.getMember().getProfileImageUrl(),
+                        review.getMember().getOnboardingProfile().getHonbobLevel().getValue()
                 ),
                 review.getKeywords(),
                 review.getCreatedAt(),

--- a/src/test/java/com/bobeat/backend/domain/member/entity/MemberOnboardingProfileTest.java
+++ b/src/test/java/com/bobeat/backend/domain/member/entity/MemberOnboardingProfileTest.java
@@ -43,11 +43,11 @@ class MemberOnboardingProfileTest {
         MemberOnboardingProfile profile = MemberOnboardingProfile.create(member, request);
 
         // when
-        Level calculatedLevel = profile.calculateAndUpdateHonbapLevel();
+        Level calculatedLevel = profile.calculateAndUpdateHonbobLevel();
 
         // then
         assertThat(calculatedLevel).isEqualTo(expectedLevel);
-        assertThat(profile.getHonbapLevel()).isEqualTo(expectedLevel);
+        assertThat(profile.getHonbobLevel()).isEqualTo(expectedLevel);
     }
 
     static Stream<Arguments> provideLevelCalculationTestCases() {
@@ -119,7 +119,7 @@ class MemberOnboardingProfileTest {
         MemberOnboardingProfile profile = MemberOnboardingProfile.create(member, request);
 
         // when
-        Level calculatedLevel = profile.calculateAndUpdateHonbapLevel();
+        Level calculatedLevel = profile.calculateAndUpdateHonbobLevel();
 
         // then
         assertThat(calculatedLevel).isEqualTo(Level.LEVEL_2);

--- a/src/test/java/com/bobeat/backend/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/bobeat/backend/domain/review/service/ReviewServiceTest.java
@@ -1,6 +1,9 @@
 package com.bobeat.backend.domain.review.service;
 
+import com.bobeat.backend.domain.member.entity.Level;
 import com.bobeat.backend.domain.member.entity.Member;
+import com.bobeat.backend.domain.member.entity.MemberOnboardingProfile;
+import com.bobeat.backend.domain.member.repository.MemberOnboardingProfileRepository;
 import com.bobeat.backend.domain.member.repository.MemberRepository;
 import com.bobeat.backend.domain.review.dto.request.CreateReviewRequest;
 import com.bobeat.backend.domain.review.dto.request.UpdateReviewRequest;
@@ -22,7 +25,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -37,6 +39,9 @@ class ReviewServiceTest {
     
     @Mock
     private StoreRepository storeRepository;
+
+    @Mock
+    private MemberOnboardingProfileRepository onboardingProfileRepository;
     
     @InjectMocks
     private ReviewService reviewService;
@@ -150,9 +155,23 @@ class ReviewServiceTest {
     }
 
     private Member createMember(Long memberId) {
-        return Member.builder()
+
+        Member member =  Member.builder()
                 .id(memberId)
                 .nickname("테스트유저")
+                .build();
+
+        MemberOnboardingProfile onboardingProfile = createOnboardingProfile(member);
+        member.setOnboardingProfile(onboardingProfile);
+
+        return member;
+    }
+
+    private MemberOnboardingProfile createOnboardingProfile(Member member) {
+        return MemberOnboardingProfile.builder()
+                .id(1L)
+                .member(member)
+                .honbobLevel(Level.LEVEL_3)
                 .build();
     }
 


### PR DESCRIPTION
## 🔖 Title
[Food][Fix] 리뷰 조회 시 레벨까지 받아올 수 있도록 수정

### 1. Summary 📝
[Food][Fix] 리뷰 조회 시 레벨까지 받아올 수 있도록 수정


### 2. Related Issue 🔗
- Close #123

### 3. Domain
- [ ] User 👤
- [ ] Admin 🛠️
- [x] Food 🍔

### 4. Type
- [x] Feature ✨
- [ ] Bug Fix 🐛
- [ ] Refactor ♻️
- [ ] Docs 📚


### 5. Changes(detail)
1. honbapLevel -> honbobLevel로 컬럼 명 수정
2. 리뷰 조회 시 유저의 혼밥레벨까지 조회 가능하도록 수정

