### PR TITLE
[Food][Fix] 가격정보 min, max nullable하도록 수정 및 불필요한 secondaryCategory 테이블 조인 제거

### DIFF
--- a/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreFilteringRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreFilteringRequest.java
@@ -65,11 +65,9 @@ public record StoreFilteringRequest(
 
         public record PriceRange(
                 @Schema(description = "최소 가격(원)", example = "8000")
-                @NotNull
                 Integer min,
 
                 @Schema(description = "최대 가격(원)", example = "15000")
-                @NotNull
                 Integer max
         ) {}
 }

--- a/src/main/java/com/bobeat/backend/domain/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bobeat/backend/domain/store/repository/StoreRepositoryImpl.java
@@ -185,13 +185,8 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
         if (request.filters().categories() == null || request.filters().categories().isEmpty()) {
             return null;
         }
-
         List<String> categories = request.filters().categories();
-
-        BooleanExpression primaryIn = store.categories.primaryCategory.primaryType.in(categories);
-        BooleanExpression secondaryIn = store.categories.secondaryCategory.secondaryType.in(categories);
-
-        return primaryIn.or(secondaryIn);
+        return store.categories.primaryCategory.primaryType.in(categories);
     }
 
     // TODO: 가격 범위 쿼리 방식 재검토(AS-IS: 서브쿼리 방식으로 추천메뉴 중 가격 조건에 맞는 메뉴가 하나라도 있는지 확인)


### PR DESCRIPTION
## 🔖 Title
[Food][Fix] 가격정보 min, max nullable하도록 수정 및 불필요한 secondaryCategory 테이블 조인 제거

### 1. Summary 📝
[Food][Fix] 가격정보 min, max nullable하도록 수정 및 불필요한 secondaryCategory 테이블 조인 제거

### 2. Related Issue 🔗
- Close #123

### 3. Domain
- [ ] User 👤
- [ ] Admin 🛠️
- [x] Food 🍔

### 4. Type
- [ ] Feature ✨
- [x] Bug Fix 🐛
- [ ] Refactor ♻️
- [ ] Docs 📚


### 5. Changes(detail)
1. 가격정보 필터 중 일부는 Null일 수 있도록 valid 제한 어노테이션 제거
2. secondaryCategory는 현재 사용하지 않는데 불필요한 조인이 걸려있어 제거

