### PR TITLE
[Common][Refactor] Store 엔티티의 mainImageUrl 필드 삭제(대표 이미지 개념 일원화 목적)

### DIFF
--- a/src/main/java/com/bobeat/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/bobeat/backend/domain/review/service/ReviewService.java
@@ -9,6 +9,8 @@ import com.bobeat.backend.domain.review.dto.response.StoreInfo;
 import com.bobeat.backend.domain.review.entity.Review;
 import com.bobeat.backend.domain.review.repository.ReviewRepository;
 import com.bobeat.backend.domain.store.entity.Store;
+import com.bobeat.backend.domain.store.entity.StoreImage;
+import com.bobeat.backend.domain.store.repository.StoreImageRepository;
 import com.bobeat.backend.domain.store.repository.StoreRepository;
 import com.bobeat.backend.global.exception.CustomException;
 import com.bobeat.backend.global.exception.ErrorCode;
@@ -26,6 +28,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
+    private final StoreImageRepository storeImageRepository;
 
     @Transactional
     public ReviewResponse createReview(Long memberId, CreateReviewRequest request) {
@@ -50,13 +53,14 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public CursorPageResponse<ReviewResponse> getReviewsByStore(Long storeId, CursorPaginationRequest request) {
         Store store = storeRepository.findByIdOrThrow(storeId);
+        StoreImage mainImage = storeImageRepository.findByStoreAndIsMainTrue(store);
 
         List<Review> reviews = reviewRepository.findByStoreIdWithCursor(storeId, request);
 
         StoreInfo metadata = new StoreInfo(
                 store.getId(),
                 store.getName(),
-                store.getMainImageUrl()
+                mainImage.getImageUrl()
         );
 
         return CursorPageResponse.of(

--- a/src/main/java/com/bobeat/backend/domain/store/entity/Store.java
+++ b/src/main/java/com/bobeat/backend/domain/store/entity/Store.java
@@ -28,8 +28,6 @@ public class Store extends BaseTimeEntity {
 
     private String description;
 
-    private String mainImageUrl;
-
     @Enumerated(EnumType.ORDINAL)
     private Level honbobLevel;
 

--- a/src/main/java/com/bobeat/backend/domain/store/repository/StoreImageRepository.java
+++ b/src/main/java/com/bobeat/backend/domain/store/repository/StoreImageRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
 
     List<StoreImage> findByStore(Store store);
+
+    StoreImage findByStoreAndIsMainTrue(Store store);
 }

--- a/src/main/java/com/bobeat/backend/domain/store/service/StoreService.java
+++ b/src/main/java/com/bobeat/backend/domain/store/service/StoreService.java
@@ -65,23 +65,25 @@ public class StoreService {
 
         List<StoreSearchResultDto> data = rows.stream()
                 .map(r -> {
-                    var s = r.store();
-                    long id = s.getId();
+                    var store = r.store();
+                    var mainImage = storeImageRepository.findByStoreAndIsMainTrue(store);
+
+                    long id = store.getId();
                     int distance = r.distance();
                     int walkingMinutes = (int) Math.ceil(distance / 80.0);
 
                     return new StoreSearchResultDto(
-                            s.getId(),
-                            s.getName(),
-                            s.getMainImageUrl(),
+                            store.getId(),
+                            store.getName(),
+                            mainImage.getImageUrl(),
                             repMenuMap.getOrDefault(id, new StoreSearchResultDto.SignatureMenu(null, 0)),
-                            new StoreSearchResultDto.Coordinate(s.getAddress().getLatitude(),
-                                    s.getAddress().getLongitude()),
+                            new StoreSearchResultDto.Coordinate(store.getAddress().getLatitude(),
+                                    store.getAddress().getLongitude()),
                             distance,
                             walkingMinutes,
                             seatTypesMap.getOrDefault(id, List.of()),
-                            buildTagsFromCategories(s.getCategories()),
-                            s.getHonbobLevel() != null ? s.getHonbobLevel().getValue() : 0
+                            buildTagsFromCategories(store.getCategories()),
+                            store.getHonbobLevel() != null ? store.getHonbobLevel().getValue() : 0
                     );
                 })
                 .collect(Collectors.toList());
@@ -143,7 +145,6 @@ public class StoreService {
                 .address(address)
                 .phoneNumber(request.phoneNumber())
                 .description(request.description())
-                .mainImageUrl(request.mainImageUrl())
                 .honbobLevel(Level.fromValue(request.honbobLevel()))
                 .categories(categories)
                 .build();


### PR DESCRIPTION
## 🔖 Title
Store 엔티티의 mainImageUrl 필드 삭제

### 1. Summary 📝
Store 엔티티의 mainImageUrl 필드 삭제(대표 이미지 개념 일원화 목적)

### 2. Related Issue 🔗

### 3. Domain
- [ ] User 👤
- [ ] Admin 🛠️
- [ ] Food 🍔
- [x] Common

### 4. Type
- [ ] Feature ✨
- [ ] Bug Fix 🐛
- [x] Refactor ♻️
- [ ] Docs 📚


### 5. Changes(detail)
1. Store.main_image_url 은 음식점 별 썸네일 이미지 주소로 필수 값으로 사용됨
2. Store 엔티티에 존재하는 **main_image_url** 필드와 **store_image** 테이블 내 **is_main** 필드를 둘 다 관리하며 데이터 불일치 위험 존재.
3. 대표 이미지 관리를 **store_image** 테이블로 일원화하여 데이터 무결성을 확보하고 관리 간소화가 목적임.
4. deploy 후 마이그레이션 방법: 
https://www.notion.so/depromeet/storeImage-29145b4338b38077b932e150ed2cef89?source=copy_link
(3.4까지는 수행 완료)

