### PR TITLE
[Food][Fix] 지도/홈 api 조회시 가격 필터조건으로 인해 조회 안되는 이슈 임시조치

### DIFF
--- a/src/main/java/com/bobeat/backend/domain/store/repository/query/StoreQueryFilterBuilder.java
+++ b/src/main/java/com/bobeat/backend/domain/store/repository/query/StoreQueryFilterBuilder.java
@@ -110,6 +110,8 @@ public class StoreQueryFilterBuilder {
     /**
      * 가격 필터를 JOIN 조건으로 빌드
      * 2단계 쿼리의 1단계(Store ID 조회)에서 사용
+     *
+     * TODO: 임시로 추천 메뉴 조건 제거 - 전체 메뉴 대상으로 가격 필터 적용
      */
     public BooleanExpression buildPriceJoinFilter(StoreFilteringRequest request) {
         if (!needsPriceJoin(request)) {
@@ -128,7 +130,8 @@ public class StoreQueryFilterBuilder {
             priceCondition = menu.price.loe(max);
         }
 
-        return menu.recommend.isTrue().and(priceCondition);
+        // 추천 메뉴 조건 제거 - 전체 메뉴에서 가격 조건 체크
+        return priceCondition;
     }
 
     /**

--- a/src/test/java/com/bobeat/backend/domain/store/repository/StoreRepositoryImplTest.java
+++ b/src/test/java/com/bobeat/backend/domain/store/repository/StoreRepositoryImplTest.java
@@ -412,7 +412,7 @@ public class StoreRepositoryImplTest {
             // then: Store A(7000원), Store C(6000원)
             assertThat(result)
                 .extracting(row -> row.store().getName())
-                .containsExactlyInAnyOrder("Store A", "Store C");
+                .containsExactlyInAnyOrder("Store A", "Store C", "Store B");
         }
 
         @Test


### PR DESCRIPTION
## 🔖 Title
[Food][Fix] 지도/홈 api 조회시 가격 필터조건으로 인해 조회 안되는 이슈 임시조치

### 1. Summary 📝
임시로 필터조건에 의해 식당 데이터 조회 안되는 이슈 수정


### 2. Related Issue 🔗
- https://github.com/depromeet/slytherin/issues/126

### 3. Domain
- [ ] User 👤
- [ ] Admin 🛠️
- [x] Food 🍔

### 4. Type
- [ ] Feature ✨
- [x] Bug Fix 🐛
- [ ] Refactor ♻️
- [ ] Docs 📚


### 5. Changes(detail)
1. 클라이언트에서 요청에 가격정보 필터가 기본으로 걸려서 들어오는데 식당 데이터 조회 시 menu 중 recommend인 것만 join해서 조회함.
2. admin 페이지에서 insert할 때 추천 메뉴 선택란이 없음-> menu.isRecommend가 전부 false로 들어가서 조회 불가
3. 임시로 가게의 전체 메뉴 중에서 가격 필터를 걸어서 조회하도록 수정, 추후 수정 필요

