### PR TITLE
[Store][Fix] StoreFilteringRequest Swagger 스키마 오류 수정

### DIFF
--- a/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreFilteringRequest.java
+++ b/src/main/java/com/bobeat/backend/domain/store/dto/request/StoreFilteringRequest.java
@@ -65,11 +65,11 @@ public record StoreFilteringRequest(
                 @NotNull
                 List<Integer> honbobLevel,
 
-                @Schema(description = "좌석 형태", example = "[\"FOR_ONE\", \", \"FOR_TWO\"\", \"FOR_FOUR\", \", \"CUBICLE\"\", \"BAR_TABLE\"]")
+                @Schema(description = "좌석 형태", example = "[\"FOR_ONE\", \"FOR_TWO\", \"FOR_FOUR\", \"CUBICLE\", \"BAR_TABLE\"]")
                 List<SeatType> seatTypes,
 
                 // TODO: ENUM 생성시 변경
-                @Schema(description = "메뉴 카테고리", example = "[\"한식\", \"일식\", \"중식\", \"양식\", \"패스트푸드\", \"분식\", \"아시아음식\", \"카페\", \"기타\"]")
+                @Schema(description = "메뉴 카테고리 (한식, 일식, 중식, 양식, 패스트푸드, 분식, 아시아음식, 카페, 기타)", example = "[\"한식\", \"일식\"]")
                 List<String> categories
         ) {}
 


### PR DESCRIPTION
## 🔖 Title
[Store][Fix] StoreFilteringRequest Swagger 스키마 오류 수정

### 1. Summary 📝
swagger 호출 시 서버 내 500에러 발생
-> seatTypes example JSON 이스케이프 오류 수정 필요


### 2. Related Issue 🔗
https://github.com/depromeet/slytherin/issues/138

### 3. Domain
- [ ] User 👤
- [ ] Admin 🛠️
- [x] Food 🍔

### 4. Type
- [ ] Feature ✨
- [x] Bug Fix 🐛
- [ ] Refactor ♻️
- [ ] Docs 📚


### 5. Changes(detail)
<img width="1914" height="510" alt="image" src="https://github.com/user-attachments/assets/b05fbc2c-7a45-4816-8361-ab0c7f8ae6c6" />

- seatTypes example의 JSON 이스케이프 오류 수정으로 Swagger 500 에러 해결
 - categories description에 가능한 값 명시 및 example 간소화
 
<img width="884" height="521" alt="image" src="https://github.com/user-attachments/assets/e3969441-0a1b-4aa3-b581-fbb07a6484c2" />

- 위이미지처럼 이제 잘 보임
